### PR TITLE
Add unit tests for configuration helpers

### DIFF
--- a/Train-Color-Matcher.py
+++ b/Train-Color-Matcher.py
@@ -55,6 +55,12 @@ CLOUD_VELOCITY_RANGE = (0.5, 1.5)  # Range of cloud velocities
 CLOUD_HEIGHT_RANGE = (50, 150)  # Range of cloud heights
 CLOUD_SEGMENT_SIZES = [20, 25, 20]  # Sizes of cloud segments
 
+# Initialize audio mixer before the rest of Pygame bootstraps to avoid stutter
+try:
+    pygame.mixer.pre_init(44100, -16, 2, 512)
+except pygame.error as error:
+    print(f"Warning: Unable to pre-initialize audio mixer: {error}")
+
 # Initialize Pygame and fonts module
 pygame.init()  # Initialize Pygame
 pygame.font.init()  # Initialize the font module
@@ -223,6 +229,9 @@ BLUE = (0, 0, 255)  # Blue color
 GREEN = (0, 255, 0)  # Green color
 GRAY = (128, 128, 128)  # Gray color
 YELLOW = (255, 255, 0)  # Yellow color
+PURPLE = (155, 89, 182)  # Purple color
+ORANGE = (255, 140, 0)  # Orange color
+CYAN = (0, 188, 212)  # Cyan color
 
 # Theme colors: Define color schemes for light and dark themes
 LIGHT_THEME = {
@@ -256,8 +265,431 @@ MENU = "menu"  # Menu game state
 PLAYING = "playing"  # Playing game state
 GAME_OVER = "game_over"  # Game over game state
 
-# Train colors: Define available train colors
-TRAIN_COLORS = [RED, BLUE, GREEN]  # List of train colors
+# Color identifiers used for accessibility overlays
+COLOR_IDENTIFIERS = {
+    RED: {"label": "R", "symbol": "⬤"},
+    BLUE: {"label": "B", "symbol": "■"},
+    GREEN: {"label": "G", "symbol": "▲"},
+    YELLOW: {"label": "Y", "symbol": "★"},
+    PURPLE: {"label": "P", "symbol": "◆"},
+    ORANGE: {"label": "O", "symbol": "⬟"},
+    CYAN: {"label": "C", "symbol": "✦"},
+}
+
+# Train colors: Define the global pool of available train colors
+TRAIN_COLORS = list(COLOR_IDENTIFIERS.keys())
+
+def wrap_text(text: str, font: pygame.font.Font, max_width: int) -> List[str]:
+    """Simple word-wrapping helper for rendering multi-line strings."""
+    words = text.split()
+    if not words:
+        return [""]
+
+    lines: List[str] = []
+    current_line = words[0]
+    for word in words[1:]:
+        test_line = f"{current_line} {word}"
+        if font.size(test_line)[0] <= max_width:
+            current_line = test_line
+        else:
+            lines.append(current_line)
+            current_line = word
+    lines.append(current_line)
+    return lines
+
+# Multilingual text catalog for UI and feedback messages
+LANGUAGE_PACKS = {
+    "en": {
+        "title": "Train Color Matcher",
+        "start": "Start Game",
+        "quit": "Quit",
+        "play_again": "Play Again",
+        "settings": "Settings",
+        "mode": "Mode",
+        "mode_campaign": "Campaign",
+        "mode_endless": "Endless",
+        "mode_switch_warning": "Switched to {mode} mode. Routes have been reset.",
+        "language": "Language",
+        "color_mode": "Color Icons",
+        "color_mode_on": "Symbols On",
+        "color_mode_off": "Symbols Off",
+        "difficulty": "Difficulty",
+        "difficulty_standard": "Standard",
+        "difficulty_relaxed": "Relaxed",
+        "difficulty_expert": "Expert",
+        "instruction_base": "Match the trains starting from the left!",
+        "message_correct": "Correct!",
+        "message_wrong": "Wrong Color!",
+        "message_click_train": "Please click on a train!",
+        "message_no_trains": "No more trains to match!",
+        "score": "Score",
+        "remaining": "Remaining",
+        "mistakes": "Mistakes",
+        "level_label": "Level",
+        "high_score": "High Score",
+        "new_level": "Level {level} - {name}",
+        "game_over": "Game Over!",
+        "final_score": "Final Score: {score}",
+        "reason_victory": "Amazing! You completed every route!",
+        "reason_mistakes": "The station closed after too many mix-ups.",
+        "reason_quit": "Come back soon for more rail puzzles!",
+        "level_rookie": "Rookie Rails",
+        "level_rookie_desc": "Match the primary engines to depart the station.",
+        "level_sunset": "Sunset Shuffle",
+        "level_sunset_desc": "Yellow coaches join the rush hour lineup!",
+        "level_twilight": "Twilight Tracks",
+        "level_twilight_desc": "Purple night trains tighten the timing.",
+        "level_aurora": "Aurora Express",
+        "level_aurora_desc": "Every color sprints across dazzling rails.",
+        "level_blizzard": "Blizzard Belt",
+        "level_blizzard_desc": "Snow squalls veil the rails. Follow the glows carefully.",
+        "level_mirage": "Mirage Metro",
+        "level_mirage_desc": "Signals surge in waves—stay alert for rapid departures.",
+        "level_endless": "Endless Stage {stage}",
+        "level_endless_desc": "Infinite dispatch! Each wave crowds the platform with faster trains.",
+        "settings_title": "Game Settings",
+        "language_cycle": "Switch Language",
+        "difficulty_cycle": "Toggle Difficulty",
+        "symbols_cycle": "Toggle Symbols",
+        "mode_cycle": "Toggle Mode",
+        "victory_banner": "All routes cleared!",
+        "mistake_recovered": "Signal restored! Mistake forgiven.",
+        "modifiers_title": "Route Conditions",
+        "modifier_dense_fog": "Track Fog",
+        "modifier_dense_fog_desc": "Low-lying fog obscures engines as they depart.",
+        "modifier_express_signals": "Express Signals",
+        "modifier_express_signals_desc": "Dispatch surges periodically accelerate outgoing trains.",
+        "combo_meter_label": "Signal Bonus",
+        "zen_mode": "Zen Mode",
+        "zen_mode_on": "Zen On",
+        "zen_mode_off": "Zen Off",
+        "zen_hint": "Relaxed play with limitless retries.",
+        "zen_reminder": "Zen active — enjoy the ride!",
+        "express_start": "Express signals! Departures speed up!",
+        "express_end": "Signals stable. Pace returning to normal.",
+    },
+    "es": {
+        "title": "Emparejador de Trenes",
+        "start": "Comenzar",
+        "quit": "Salir",
+        "play_again": "Jugar de Nuevo",
+        "settings": "Configuración",
+        "mode": "Modo",
+        "mode_campaign": "Campaña",
+        "mode_endless": "Infinito",
+        "mode_switch_warning": "Modo cambiado a {mode}. Las rutas se reinician.",
+        "language": "Idioma",
+        "color_mode": "Iconos de Color",
+        "color_mode_on": "Símbolos Activados",
+        "color_mode_off": "Símbolos Desactivados",
+        "difficulty": "Dificultad",
+        "difficulty_standard": "Normal",
+        "difficulty_relaxed": "Relajado",
+        "difficulty_expert": "Experto",
+        "instruction_base": "¡Empareja los trenes comenzando desde la izquierda!",
+        "message_correct": "¡Correcto!",
+        "message_wrong": "¡Color incorrecto!",
+        "message_click_train": "¡Haz clic en un tren!",
+        "message_no_trains": "¡No quedan trenes!",
+        "score": "Puntuación",
+        "remaining": "Restantes",
+        "mistakes": "Errores",
+        "level_label": "Nivel",
+        "high_score": "Récord",
+        "new_level": "Nivel {level} - {name}",
+        "game_over": "¡Fin del Juego!",
+        "final_score": "Puntuación Final: {score}",
+        "reason_victory": "¡Increíble! ¡Completaste todas las rutas!",
+        "reason_mistakes": "La estación cerró tras demasiados errores.",
+        "reason_quit": "¡Vuelve pronto para más rompecabezas!",
+        "level_rookie": "Rieles Novatos",
+        "level_rookie_desc": "Empareja los trenes primarios para salir de la estación.",
+        "level_sunset": "Mezcla del Atardecer",
+        "level_sunset_desc": "¡Los coches amarillos se unen a la hora pico!",
+        "level_twilight": "Vías del Crepúsculo",
+        "level_twilight_desc": "Los trenes morados nocturnos ajustan el ritmo.",
+        "level_aurora": "Expreso Aurora",
+        "level_aurora_desc": "Cada color corre por rieles brillantes.",
+        "level_blizzard": "Corredor Nevado",
+        "level_blizzard_desc": "Las ventiscas cubren los rieles. Sigue los destellos con cuidado.",
+        "level_mirage": "Metro Espejismo",
+        "level_mirage_desc": "Las señales suben en oleadas: ¡atento a las salidas rápidas!",
+        "level_endless": "Etapa Infinita {stage}",
+        "level_endless_desc": "¡Despacho infinito! Cada oleada llena el andén con trenes más veloces.",
+        "settings_title": "Configuración del Juego",
+        "language_cycle": "Cambiar Idioma",
+        "difficulty_cycle": "Cambiar Dificultad",
+        "symbols_cycle": "Alternar Símbolos",
+        "mode_cycle": "Cambiar Modo",
+        "victory_banner": "¡Todas las rutas completas!",
+        "mistake_recovered": "¡Señal restablecida! Error perdonado.",
+        "modifiers_title": "Condiciones de Ruta",
+        "modifier_dense_fog": "Niebla en la Vía",
+        "modifier_dense_fog_desc": "La niebla baja oculta las locomotoras al partir.",
+        "modifier_express_signals": "Señales Exprés",
+        "modifier_express_signals_desc": "Los despachos en oleadas aceleran los trenes periódicamente.",
+        "combo_meter_label": "Bono de Señal",
+        "zen_mode": "Modo Zen",
+        "zen_mode_on": "Zen Activado",
+        "zen_mode_off": "Zen Desactivado",
+        "zen_hint": "Juego relajado con intentos infinitos.",
+        "zen_reminder": "Modo Zen activo: ¡disfruta del viaje!",
+        "express_start": "¡Señales exprés! ¡Las salidas se aceleran!",
+        "express_end": "Señales estables. El ritmo vuelve a la normalidad.",
+    },
+    "fr": {
+        "title": "Match des Trains",
+        "start": "Jouer",
+        "quit": "Quitter",
+        "play_again": "Rejouer",
+        "settings": "Options",
+        "mode": "Mode",
+        "mode_campaign": "Campagne",
+        "mode_endless": "Infini",
+        "mode_switch_warning": "Mode changé pour {mode}. Les parcours sont réinitialisés.",
+        "language": "Langue",
+        "color_mode": "Symboles",
+        "color_mode_on": "Symboles Activés",
+        "color_mode_off": "Symboles Désactivés",
+        "difficulty": "Difficulté",
+        "difficulty_standard": "Classique",
+        "difficulty_relaxed": "Détendu",
+        "difficulty_expert": "Expert",
+        "instruction_base": "Associez les trains en partant de la gauche !",
+        "message_correct": "Bravo !",
+        "message_wrong": "Mauvaise couleur !",
+        "message_click_train": "Cliquez sur un train !",
+        "message_no_trains": "Plus de trains à associer !",
+        "score": "Score",
+        "remaining": "Restants",
+        "mistakes": "Erreurs",
+        "level_label": "Niveau",
+        "high_score": "Record",
+        "new_level": "Niveau {level} - {name}",
+        "game_over": "Fin de Partie !",
+        "final_score": "Score Final : {score}",
+        "reason_victory": "Superbe ! Toutes les voies sont terminées !",
+        "reason_mistakes": "La gare ferme après trop d'erreurs.",
+        "reason_quit": "Revenez bientôt pour d'autres défis !",
+        "level_rookie": "Rails Débutants",
+        "level_rookie_desc": "Associez les locomotives primaires pour démarrer.",
+        "level_sunset": "Mélodie du Crépuscule",
+        "level_sunset_desc": "Les wagons jaunes rejoignent l'heure de pointe !",
+        "level_twilight": "Voies du Soir",
+        "level_twilight_desc": "Les trains violets nocturnes resserrent le rythme.",
+        "level_aurora": "Express Aurore",
+        "level_aurora_desc": "Chaque couleur file sur des rails scintillants.",
+        "level_blizzard": "Couloir Blizzard",
+        "level_blizzard_desc": "Les rafales de neige voilent les rails. Suivez bien les lueurs.",
+        "level_mirage": "Métro Mirage",
+        "level_mirage_desc": "Les signaux montent en vagues—restez alerte aux départs rapides.",
+        "level_endless": "Étape Infinie {stage}",
+        "level_endless_desc": "Départs sans fin ! Chaque vague accélère la cadence.",
+        "settings_title": "Paramètres du Jeu",
+        "language_cycle": "Changer de Langue",
+        "difficulty_cycle": "Changer la Difficulté",
+        "symbols_cycle": "Basculer les Symboles",
+        "mode_cycle": "Changer de Mode",
+        "victory_banner": "Toutes les voies dégagées !",
+        "mistake_recovered": "Signal rétabli ! Faute annulée.",
+        "modifiers_title": "Conditions de Ligne",
+        "modifier_dense_fog": "Brouillard sur les Voies",
+        "modifier_dense_fog_desc": "Un brouillard bas dissimule les locomotives au départ.",
+        "modifier_express_signals": "Signaux Express",
+        "modifier_express_signals_desc": "Des poussées d'envoi accélèrent les trains périodiquement.",
+        "combo_meter_label": "Bonus de Signal",
+        "zen_mode": "Mode Zen",
+        "zen_mode_on": "Zen Activé",
+        "zen_mode_off": "Zen Désactivé",
+        "zen_hint": "Partie détendue avec essais illimités.",
+        "zen_reminder": "Mode Zen actif — profitez du trajet !",
+        "express_start": "Signaux express ! Les départs s'accélèrent !",
+        "express_end": "Signaux stables. Le rythme redevient normal.",
+    },
+    "de": {
+        "title": "Zugfarbenspiel",
+        "start": "Spiel Starten",
+        "quit": "Beenden",
+        "play_again": "Nochmal",
+        "settings": "Einstellungen",
+        "mode": "Modus",
+        "mode_campaign": "Kampagne",
+        "mode_endless": "Endlos",
+        "mode_switch_warning": "Modus auf {mode} gewechselt. Fahrten werden zurückgesetzt.",
+        "language": "Sprache",
+        "color_mode": "Farbsymbole",
+        "color_mode_on": "Symbole An",
+        "color_mode_off": "Symbole Aus",
+        "difficulty": "Schwierigkeit",
+        "difficulty_standard": "Standard",
+        "difficulty_relaxed": "Entspannt",
+        "difficulty_expert": "Experte",
+        "instruction_base": "Ordne die Züge von links beginnend zu!",
+        "message_correct": "Richtig!",
+        "message_wrong": "Falsche Farbe!",
+        "message_click_train": "Bitte einen Zug anklicken!",
+        "message_no_trains": "Keine Züge mehr zum Zuordnen!",
+        "score": "Punkte",
+        "remaining": "Verbleibend",
+        "mistakes": "Fehler",
+        "level_label": "Stufe",
+        "high_score": "Rekord",
+        "new_level": "Stufe {level} - {name}",
+        "game_over": "Spiel Vorbei!",
+        "final_score": "Endstand: {score}",
+        "reason_victory": "Großartig! Alle Strecken abgeschlossen!",
+        "reason_mistakes": "Zu viele Verwechslungen im Bahnhof.",
+        "reason_quit": "Bis bald für mehr Rätsel!",
+        "level_rookie": "Neulingsgleise",
+        "level_rookie_desc": "Bringe die Grundfarben richtig auf die Reise.",
+        "level_sunset": "Abendexpress",
+        "level_sunset_desc": "Gelbe Wagen mischen sich in die Rushhour!",
+        "level_twilight": "Dämmerungstrassen",
+        "level_twilight_desc": "Violette Nachtzüge erhöhen das Tempo.",
+        "level_aurora": "Aurora-Express",
+        "level_aurora_desc": "Alle Farben rasen über funkelnde Schienen.",
+        "level_blizzard": "Blizzard-Strecke",
+        "level_blizzard_desc": "Schneestürme verhüllen die Gleise. Folge den Lichtern genau.",
+        "level_mirage": "Mirage-Metro",
+        "level_mirage_desc": "Signale kommen in Wellen – bleib wachsam bei schnellen Abfahrten.",
+        "level_endless": "Endlos-Stufe {stage}",
+        "level_endless_desc": "Endlose Abfahrten! Jede Welle wird schneller und dichter.",
+        "settings_title": "Spieleinstellungen",
+        "language_cycle": "Sprache wechseln",
+        "difficulty_cycle": "Schwierigkeit ändern",
+        "symbols_cycle": "Symbole umschalten",
+        "mode_cycle": "Modus wechseln",
+        "victory_banner": "Alle Strecken frei!",
+        "mistake_recovered": "Signal wieder grün! Fehler verziehen.",
+        "modifiers_title": "Streckenzustand",
+        "modifier_dense_fog": "Gleisnebel",
+        "modifier_dense_fog_desc": "Tiefer Nebel verbirgt abfahrende Lokomotiven.",
+        "modifier_express_signals": "Express-Signale",
+        "modifier_express_signals_desc": "Schubweise Freigaben beschleunigen die Züge regelmäßig.",
+        "combo_meter_label": "Signalbonus",
+        "zen_mode": "Zen-Modus",
+        "zen_mode_on": "Zen Aktiv",
+        "zen_mode_off": "Zen Aus",
+        "zen_hint": "Entspannter Modus mit unbegrenzten Versuchen.",
+        "zen_reminder": "Zen-Modus aktiv – genieße die Fahrt!",
+        "express_start": "Express-Signale! Die Abfahrten werden schneller!",
+        "express_end": "Signale stabil. Das Tempo beruhigt sich.",
+    }
+}
+
+DEFAULT_LANGUAGE = "en"
+
+
+class LanguageManager:
+    """Simple helper for retrieving localized UI strings."""
+
+    def __init__(self, language_code: str = DEFAULT_LANGUAGE):
+        self.language_code = language_code if language_code in LANGUAGE_PACKS else DEFAULT_LANGUAGE
+
+    def set_language(self, language_code: str) -> None:
+        if language_code in LANGUAGE_PACKS:
+            self.language_code = language_code
+
+    def cycle_language(self) -> None:
+        codes = list(LANGUAGE_PACKS.keys())
+        current_index = codes.index(self.language_code)
+        self.language_code = codes[(current_index + 1) % len(codes)]
+
+    def get_text(self, key: str, **kwargs) -> str:
+        base = LANGUAGE_PACKS.get(self.language_code, {})
+        fallback = LANGUAGE_PACKS[DEFAULT_LANGUAGE]
+        template = base.get(key, fallback.get(key, key))
+        try:
+            return template.format(**kwargs)
+        except (KeyError, IndexError):
+            return template
+
+    def get_language_label(self) -> str:
+        names = {
+            "en": "English",
+            "es": "Español",
+            "fr": "Français",
+            "de": "Deutsch",
+        }
+        return names.get(self.language_code, self.language_code)
+
+    def get_available_languages(self):
+        return list(LANGUAGE_PACKS.keys())
+
+
+LEVEL_CONFIGS = [
+    {
+        "name_key": "level_rookie",
+        "description_key": "level_rookie_desc",
+        "colors": [RED, BLUE, GREEN],
+        "train_speed": 5,
+        "max_trains": 8,
+        "spacing": 90,
+        "mistakes_allowed": 3,
+        "modifiers": [],
+    },
+    {
+        "name_key": "level_sunset",
+        "description_key": "level_sunset_desc",
+        "colors": [RED, BLUE, GREEN, YELLOW],
+        "train_speed": 6,
+        "max_trains": 10,
+        "spacing": 85,
+        "mistakes_allowed": 3,
+        "modifiers": [],
+    },
+    {
+        "name_key": "level_twilight",
+        "description_key": "level_twilight_desc",
+        "colors": [RED, BLUE, GREEN, YELLOW, PURPLE],
+        "train_speed": 7,
+        "max_trains": 12,
+        "spacing": 80,
+        "mistakes_allowed": 2,
+        "modifiers": ["express_signals"],
+    },
+    {
+        "name_key": "level_aurora",
+        "description_key": "level_aurora_desc",
+        "colors": [RED, BLUE, GREEN, YELLOW, PURPLE, ORANGE, CYAN],
+        "train_speed": 8,
+        "max_trains": 14,
+        "spacing": 75,
+        "mistakes_allowed": 2,
+        "modifiers": ["express_signals"],
+    },
+    {
+        "name_key": "level_blizzard",
+        "description_key": "level_blizzard_desc",
+        "colors": [RED, BLUE, GREEN, YELLOW, PURPLE, ORANGE, CYAN],
+        "train_speed": 8.5,
+        "max_trains": 15,
+        "spacing": 72,
+        "mistakes_allowed": 2,
+        "modifiers": ["dense_fog"],
+    },
+    {
+        "name_key": "level_mirage",
+        "description_key": "level_mirage_desc",
+        "colors": [RED, BLUE, GREEN, YELLOW, PURPLE, ORANGE, CYAN],
+        "train_speed": 9,
+        "max_trains": 16,
+        "spacing": 68,
+        "mistakes_allowed": 1,
+        "modifiers": ["express_signals", "dense_fog"],
+    },
+]
+
+MODIFIER_DEFINITIONS = {
+    "dense_fog": {
+        "name_key": "modifier_dense_fog",
+        "description_key": "modifier_dense_fog_desc",
+    },
+    "express_signals": {
+        "name_key": "modifier_express_signals",
+        "description_key": "modifier_express_signals_desc",
+    },
+}
 
 # Font settings: Define font path
 FONT_PATH = os.path.join(FONTS_DIR, "RobotoCondensed-Italic-VariableFont_wght.ttf")  # Font path
@@ -271,43 +703,136 @@ except:
 
 # Sound manager class to handle game sounds
 class SoundManager:
-    # Initializes the sound manager
+    """Centralised audio hub for both sound effects and background music."""
+
     def __init__(self):
+        self.available = True
+        self.muted = False
+        self.sfx_volume = 0.7
+        self.music_volume = 0.45
+        self.current_music: str | None = None
+        self.sounds: Dict[str, pygame.mixer.Sound] = {}
+        self.sound_volumes: Dict[str, float] = {}
+        self.music_tracks: Dict[str, str] = {}
+
         try:
-            self.sounds = {
-                'correct': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'General_sound_effect.mp3')),  # Correct sound
-                'wrong': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Suspenseful Music.mp3')),  # Wrong sound
-                'click': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Button sounds.mp3')),  # Click sound
-                'game_over': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Cutscene Music.mp3')),  # Game over sound
-                'background': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Menu Music.mp3')),  # Background music
-                'button_hover': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'UI opening sounds.mp3')),  # Button hover sound
-                'level_up': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'MC Level Up.mp3')),  # Level up sound
-                'victory': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Victory Music.mp3')),  # Victory sound
-                'item_pickup': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Item Pickup.mp3')),  # Item pickup sound
-                'confirmation': pygame.mixer.Sound(os.path.join(SOUNDS_DIR, 'Confirmation Sounds (in UI).mp3'))  # Confirmation sound
-            }
-            self.sounds['background'].set_volume(0.5)  # Set background music volume
-            self.sounds['background'].play(-1)  # Play background music on loop
-        except:
-            print("Warning: Sound files not found. Running without sound.")  # Print a warning if sound files are not found
-            self.sounds = {}  # Initialize an empty sound dictionary
-        self.muted = False  # Initialize muted state
+            if not pygame.mixer.get_init():
+                pygame.mixer.init()
+        except pygame.error as error:
+            print(f"Warning: Audio disabled: {error}")
+            self.available = False
+            return
 
-    # Plays a sound
-    def play(self, sound_name):
-        if not self.muted and sound_name in self.sounds:  # Check if not muted and sound exists
+        self._load_assets()
+
+    def _load_assets(self) -> None:
+        """Load sound effects and register music tracks."""
+
+        def load_sound(key: str, filename: str, base_volume: float = 1.0) -> None:
+            if not self.available:
+                return
+            path = os.path.join(SOUNDS_DIR, filename)
+            if not os.path.exists(path):
+                print(f"Warning: Missing sound effect '{filename}'")
+                return
             try:
-                self.sounds[sound_name].play()  # Play the sound
-            except:
-                pass
+                sound = pygame.mixer.Sound(path)
+                self.sounds[key] = sound
+                self.sound_volumes[key] = base_volume
+                sound.set_volume(0 if self.muted else base_volume * self.sfx_volume)
+            except pygame.error as error:
+                print(f"Warning: Failed to load sound '{filename}': {error}")
 
-    # Toggles mute state
-    def toggle_mute(self):
-        self.muted = not self.muted  # Toggle muted state
-        if self.muted:
-            pygame.mixer.pause()  # Pause all sounds
-        else:
-            pygame.mixer.unpause()  # Unpause all sounds
+        def register_music(key: str, filename: str) -> None:
+            path = os.path.join(SOUNDS_DIR, filename)
+            if os.path.exists(path):
+                self.music_tracks[key] = path
+            else:
+                print(f"Warning: Missing music track '{filename}'")
+
+        load_sound('correct', 'General_sound_effect.mp3')
+        load_sound('wrong', 'Suspenseful Music.mp3', 0.8)
+        load_sound('click', 'Button sounds.mp3', 0.6)
+        load_sound('button_hover', 'UI opening sounds.mp3', 0.5)
+        load_sound('level_up', 'MC Level Up.mp3', 0.7)
+        load_sound('victory', 'Victory Music.mp3', 0.7)
+        load_sound('item_pickup', 'Item Pickup.mp3', 0.65)
+        load_sound('confirmation', 'Confirmation Sounds (in UI).mp3', 0.6)
+        load_sound('game_over_sting', 'Cutscene Music.mp3', 0.8)
+        load_sound('recovery', 'Recovery sound .mp3', 0.7)
+
+        register_music('menu', 'Menu Music.mp3')
+        register_music('campaign', 'Shop_MusicMerchant_T.mp3')
+        register_music('endless', 'Boss Battle .mp3')
+        register_music('game_over', 'Cutscene Music.mp3')
+        register_music('victory_theme', 'Victory Music.mp3')
+
+    def play(self, sound_name: str) -> None:
+        if not self.available or self.muted:
+            return
+        sound = self.sounds.get(sound_name)
+        if sound is None:
+            return
+        try:
+            base_volume = self.sound_volumes.get(sound_name, 1.0)
+            sound.set_volume(base_volume * self.sfx_volume)
+            sound.play()
+        except pygame.error:
+            pass
+
+    def play_music(self, track_name: str, loop: bool = True, fade_ms: int = 500) -> None:
+        if not self.available:
+            return
+        path = self.music_tracks.get(track_name)
+        if path is None:
+            return
+        if self.current_music == track_name and pygame.mixer.music.get_busy():
+            return
+        try:
+            pygame.mixer.music.load(path)
+            pygame.mixer.music.set_volume(0 if self.muted else self.music_volume)
+            loops = -1 if loop else 0
+            pygame.mixer.music.play(loops=loops, fade_ms=fade_ms)
+            self.current_music = track_name
+        except pygame.error as error:
+            print(f"Warning: Unable to play music '{track_name}': {error}")
+
+    def stop_music(self, fade_ms: int = 300) -> None:
+        if not self.available:
+            return
+        try:
+            pygame.mixer.music.fadeout(fade_ms)
+        except pygame.error:
+            pass
+        self.current_music = None
+
+    def set_sfx_volume(self, volume: float) -> None:
+        self.sfx_volume = max(0.0, min(1.0, volume))
+        self._refresh_sfx_volumes()
+
+    def set_music_volume(self, volume: float) -> None:
+        self.music_volume = max(0.0, min(1.0, volume))
+        if not self.available:
+            return
+        pygame.mixer.music.set_volume(0 if self.muted else self.music_volume)
+
+    def _refresh_sfx_volumes(self) -> None:
+        if not self.available:
+            return
+        for key, sound in self.sounds.items():
+            base_volume = self.sound_volumes.get(key, 1.0)
+            sound.set_volume(0 if self.muted else base_volume * self.sfx_volume)
+
+    def toggle_mute(self) -> None:
+        if not self.available:
+            self.muted = True
+            return
+        self.muted = not self.muted
+        pygame.mixer.music.set_volume(0 if self.muted else self.music_volume)
+        self._refresh_sfx_volumes()
+
+    def is_music_playing(self, track_name: str) -> bool:
+        return self.available and self.current_music == track_name and pygame.mixer.music.get_busy()
 
 # Particle class for visual effects
 class Particle:
@@ -488,27 +1013,68 @@ class TrainRenderer:
         self.train = train  # Train
 
     # Draws the train
-    def draw(self, screen, is_dark_mode=False):
-        pygame.draw.rect(screen, self.train.color, 
-            (self.train.x, self.train.y, 
-             CONFIG["train"]["width"], CONFIG["train"]["height"]), 
-            border_radius=5)  # Draw the train body
-        
-        pygame.draw.rect(screen, (50, 50, 50), 
-            (self.train.x + 10, self.train.y - 10, 10, 10))  # Draw the train chimney
-        
+    def draw(self, screen, is_dark_mode: bool = False, show_identifier: bool = False):
+        pygame.draw.rect(
+            screen,
+            self.train.color,
+            (
+                self.train.x,
+                self.train.y,
+                CONFIG["train"]["width"],
+                CONFIG["train"]["height"],
+            ),
+            border_radius=5,
+        )  # Draw the train body
+
+        pygame.draw.rect(
+            screen,
+            (50, 50, 50),
+            (self.train.x + 10, self.train.y - 10, 10, 10),
+        )  # Draw the train chimney
+
         window_color = (255, 255, 200) if is_dark_mode else (200, 200, 200)  # Window color
         if is_dark_mode:  # If dark mode is enabled
             for window_x in [self.train.x + 25, self.train.x + 45]:  # For each window
                 glow_surf = pygame.Surface((20, 20), pygame.SRCALPHA)  # Create a surface for the glow
                 pygame.draw.circle(glow_surf, (255, 255, 0, 100), (10, 10), 8)  # Draw the glow
                 screen.blit(glow_surf, (window_x - 5, self.train.y))  # Blit the glow to the screen
-        
-        pygame.draw.rect(screen, window_color, (self.train.x + 25, self.train.y + 5, 10, 10))  # Draw the first window
-        pygame.draw.rect(screen, window_color, (self.train.x + 45, self.train.y + 5, 10, 10))  # Draw the second window
-        
-        pygame.draw.circle(screen, BLACK, (self.train.x + 15, self.train.y + 30), 5)  # Draw the first wheel
-        pygame.draw.circle(screen, BLACK, (self.train.x + 45, self.train.y + 30), 5)  # Draw the second wheel
+
+        pygame.draw.rect(
+            screen, window_color, (self.train.x + 25, self.train.y + 5, 10, 10)
+        )  # Draw the first window
+        pygame.draw.rect(
+            screen, window_color, (self.train.x + 45, self.train.y + 5, 10, 10)
+        )  # Draw the second window
+
+        pygame.draw.circle(
+            screen, BLACK, (self.train.x + 15, self.train.y + 30), 5
+        )  # Draw the first wheel
+        pygame.draw.circle(
+            screen, BLACK, (self.train.x + 45, self.train.y + 30), 5
+        )  # Draw the second wheel
+
+        if self.train.identifier:
+            try:
+                font = pygame.font.Font(FONT_PATH, 26)
+            except Exception:
+                font = pygame.font.Font(None, 26)
+
+            text_color = WHITE if show_identifier else (40, 40, 40)
+            text_surface = font.render(self.train.identifier, True, text_color)
+            text_rect = text_surface.get_rect(
+                center=(
+                    self.train.x + CONFIG["train"]["width"] // 2,
+                    self.train.y + CONFIG["train"]["height"] // 2,
+                )
+            )
+
+            if show_identifier:
+                badge = pygame.Surface((text_rect.width + 12, text_rect.height + 8), pygame.SRCALPHA)
+                pygame.draw.rect(badge, (0, 0, 0, 140), badge.get_rect(), border_radius=8)
+                screen.blit(badge, (text_rect.x - 6, text_rect.y - 4))
+                text_surface = font.render(self.train.identifier, True, WHITE)
+
+            screen.blit(text_surface, text_rect)
 
         for particle in self.train.smoke_particles:  # Draw the smoke particles
             particle.draw(screen)
@@ -516,10 +1082,12 @@ class TrainRenderer:
 # Train class to handle train behavior
 class Train:
     # Initializes a train
-    def __init__(self, x, y, color):
+    def __init__(self, x, y, color, speed=5, identifier=""):
         self.x = x  # X position
         self.y = y  # Y position
         self.color = color  # Color
+        self.speed = speed  # Movement speed
+        self.identifier = identifier  # Identifier symbol for accessibility
         self.width = CONFIG["train"]["width"]  # Width
         self.height = CONFIG["train"]["height"]  # Height
         self.moving = False  # Moving state
@@ -528,16 +1096,16 @@ class Train:
         self.renderer = TrainRenderer(self)  # Train renderer
 
     # Draws the train
-    def draw(self, screen, is_dark_mode=False):
-        self.renderer.draw(screen, is_dark_mode)  # Draw the train
+    def draw(self, screen, is_dark_mode: bool = False, show_identifier: bool = False):
+        self.renderer.draw(screen, is_dark_mode, show_identifier)  # Draw the train
 
     # Moves the train
     def move(self):
         if self.moving:  # If the train is moving
             if self.move_direction == "left":  # If the train is moving left
-                self.x -= 5  # Move left
+                self.x -= self.speed  # Move left
             elif self.move_direction == "right":  # If the train is moving right
-                self.x += 5  # Move right
+                self.x += self.speed  # Move right
 
             self.emit_smoke()  # Emit smoke
 
@@ -617,30 +1185,53 @@ class ParallaxLayer:
 # Game class to handle game logic
 class Game:
     # Initializes the game
-    def __init__(self):
+    def __init__(self, language_manager: LanguageManager | None = None):
+        self.language_manager = language_manager or LanguageManager()
+        if not hasattr(self, "theme"):
+            self.theme = LIGHT_THEME
+
         self.state = MENU  # Set the initial state to MENU
-        self.reset_game()  # Reset the game
-        self.create_buttons()  # Create buttons
-        self.high_score = 0  # Initialize high score
+        self.high_score = 0  # Initialize campaign high score
+        self.endless_high_score = 0  # Separate tracker for endless runs
+        self.game_mode = 'campaign'
+        self.available_modes = ['campaign', 'endless']
+        self.endless_stage = 0
         self.sound_manager = SoundManager()  # Initialize sound manager
-        self.messages = []  # Initialize messages
+        self.messages: List['Message'] = []  # Initialize messages
+        self.explosion_particles: List[ExplosionParticle] = []  # Initialize explosion particles
         self.mute_button = Button(WIDTH - 60, 10, 50, 50, "🔊", WHITE)  # Create mute button
         self.background = pygame.Surface((WIDTH, HEIGHT))  # Create background surface
-        self.create_background()  # Create background
-        self.current_train_index = 0  # Initialize current train index
-        self.explosion_particles = []  # Initialize explosion particles
-        self.level = 1  # Initialize level
-        self.level_up_threshold = CONFIG['game']['level_up_threshold']  # Set level up threshold
-        self.train_speed = CONFIG['game']['initial_train_speed']  # Set initial train speed
-        self.max_trains = CONFIG['game']['initial_max_trains']  # Set initial max trains
-        self.train_positions = [i * 80 for i in range(self.max_trains)]  # Set train positions
-        self.font = pygame.font.Font(FONT_PATH, 36)  # Set font
+        self.combo_count = 0  # Initialize combo count
+        self.combo_message: 'ComboMessage' | None = None  # Initialize combo message
+        self.additional_mistakes = 0  # Difficulty modifier
+        self.color_blind_mode = False  # Accessibility toggle
+        self.level_index = 0  # Track the active level
+        self.level_intro_timer = 0  # Timer for level banner
+        self.game_over_reason: str | None = None  # Store why the game ended
+        self.active_modifiers: List[str] = []  # Active level modifiers
+        self.modifier_display_lines: List[Tuple[str, str]] = []  # Localised modifier descriptions
+        self.fog_phase = 0.0
+        self.fog_offsets: List[float] = []
+        self.express_timer = 0.0
+        self.express_cooldown = 0.0
+        self.express_elapsed = 0.0
+        self.express_active = False
+        self.express_announced = False
+        self.speed_multiplier = 1.0
+        self.base_level_mistakes = 3
+        self.zen_mode = False
+
         self.parallax_layers = [
             ParallaxLayer(os.path.join(IMAGES_DIR, "cloud_layer.png"), 10),
             ParallaxLayer(os.path.join(IMAGES_DIR, "tree_layer.png"), 30)
         ]
-        self.combo_count = 0  # Initialize combo count
-        self.combo_message = None  # Initialize combo message
+
+        self.create_background()
+        self.reset_game()  # Reset the game
+        self.create_buttons()  # Create buttons
+
+        if getattr(self.sound_manager, 'available', False):
+            self.sound_manager.play_music('menu')
 
     # Creates the background
     def create_background(self):
@@ -655,46 +1246,274 @@ class Game:
         self.messages = [msg for msg in self.messages if not msg.should_remove()]  # Remove old messages
         self.messages.append(Message(text, color, duration))  # Add new message
 
+    def update_mistake_limits(self, base_value: int) -> None:
+        base_value = max(1, base_value)
+        self.base_level_mistakes = base_value
+        if self.zen_mode:
+            self.max_mistakes = 999
+        else:
+            self.max_mistakes = max(1, base_value + self.additional_mistakes)
+
     # Resets the game
     def reset_game(self):
-        self.track_trains = []  # Initialize track trains
-        self.selection_trains = []  # Initialize selection trains
+        self.track_trains: List[Train] = []  # Initialize track trains
+        self.selection_trains: List[Train] = []  # Initialize selection trains
         self.score = 0  # Initialize score
+        self.mistakes = 0  # Mistakes for current level
         self.current_train_index = 0  # Initialize current train index
         self.all_trains_moving = False  # Initialize all trains moving state
         self.explosion_particles = []  # Initialize explosion particles
-        self.level = 1  # Initialize level
-        self.train_speed = 5  # Initialize train speed
-        self.max_trains = 10  # Initialize max trains
-        self.train_positions = [i * 80 for i in range(self.max_trains)]  # Set train positions
+        self.level_index = 0  # Reset level index
+        self.endless_stage = 0  # Reset endless scaling
+        self.level = 1  # Human readable level number
+        self.speed_multiplier = 1.0
+        self.express_active = False
+        self.express_announced = False
+        self.express_timer = 0.0
+        self.express_elapsed = 0.0
+        self.fog_phase = 0.0
+        self.apply_level_rules()  # Apply current level configuration
         self.initialize_trains()  # Initialize trains
         self.last_time = pygame.time.get_ticks()  # Set last time
         self.combo_count = 0  # Initialize combo count
         self.combo_message = None  # Initialize combo message
+        self.game_over_reason = None
+        self.level_intro_timer = 2.5  # Show intro banner for first level
+
+        if self.state == PLAYING and getattr(self.sound_manager, 'available', False):
+            track = 'campaign' if self.game_mode == 'campaign' else 'endless'
+            self.sound_manager.play_music(track)
 
     # Creates buttons
     def create_buttons(self):
-        self.start_button = Button(WIDTH//2 - 100, HEIGHT//2 - 50, 200, 50, "Start Game", self.theme['primary'])  # Create start button
-        self.quit_button = Button(WIDTH//2 - 100, HEIGHT//2 + 50, 200, 50, "Quit", self.theme['error'])  # Create quit button
-        self.play_again_button = Button(WIDTH//2 - 100, HEIGHT//2 + 50, 200, 50, "Play Again", self.theme['primary'])  # Create play again button
+        self.start_button = Button(
+            WIDTH//2 - 100,
+            HEIGHT//2 - 50,
+            200,
+            50,
+            self.language_manager.get_text("start"),
+            self.theme['primary']
+        )
+        self.quit_button = Button(
+            WIDTH//2 - 100,
+            HEIGHT//2 + 50,
+            200,
+            50,
+            self.language_manager.get_text("quit"),
+            self.theme['error']
+        )
+        self.play_again_button = Button(
+            WIDTH//2 - 100,
+            HEIGHT//2 + 50,
+            200,
+            50,
+            self.language_manager.get_text("play_again"),
+            self.theme['primary']
+        )
+
+    def apply_level_rules(self):
+        if self.game_mode == 'endless':
+            base_index = min(self.endless_stage, len(LEVEL_CONFIGS) - 1)
+            base_config = LEVEL_CONFIGS[base_index]
+            self.level_config = {
+                **base_config,
+                "name_key": "level_endless",
+                "description_key": "level_endless_desc",
+                "modifiers": base_config.get("modifiers", []),
+            }
+            base_speed = base_config.get("train_speed", CONFIG['game']['initial_train_speed'])
+            base_spacing = base_config.get("spacing", TRAIN_SPACING)
+            base_max = base_config.get("max_trains", CONFIG['game']['initial_max_trains'])
+            base_mistakes = base_config.get("mistakes_allowed", 3)
+
+            self.available_colors = base_config["colors"]
+            self.train_speed = base_speed + min(self.endless_stage * 0.35, 3.5)
+            self.max_trains = min(base_max + self.endless_stage // 2, 18)
+            self.train_spacing = max(55, base_spacing - self.endless_stage * 2)
+            penalty = self.endless_stage // 3
+            base_value = max(1, base_mistakes - penalty)
+            self.active_modifiers = list(self.level_config.get("modifiers", []))
+            if self.endless_stage >= 2 and "express_signals" not in self.active_modifiers:
+                self.active_modifiers.append("express_signals")
+            if self.endless_stage >= 4 and "dense_fog" not in self.active_modifiers:
+                self.active_modifiers.append("dense_fog")
+            self.update_mistake_limits(base_value)
+        else:
+            self.level_config = LEVEL_CONFIGS[self.level_index]
+            self.available_colors = self.level_config["colors"]
+            self.train_speed = self.level_config.get("train_speed", CONFIG['game']['initial_train_speed'])
+            self.max_trains = self.level_config.get("max_trains", CONFIG['game']['initial_max_trains'])
+            self.train_spacing = self.level_config.get("spacing", TRAIN_SPACING)
+            base_mistakes = self.level_config.get("mistakes_allowed", 3)
+            self.active_modifiers = list(self.level_config.get("modifiers", []))
+            self.update_mistake_limits(base_mistakes)
+
+        self._reset_modifier_runtime()
+        self.refresh_level_texts()
+
+    def _reset_modifier_runtime(self) -> None:
+        self.active_modifiers = list(dict.fromkeys(self.active_modifiers))
+        self.modifier_display_lines = []
+        self.fog_phase = 0.0
+        self.fog_offsets = [random.random() * math.tau for _ in range(6)]
+        self.express_timer = 0.0
+        self.express_elapsed = 0.0
+        self.express_cooldown = random.uniform(7.0, 11.0)
+        self.express_active = False
+        self.express_announced = False
+        self.speed_multiplier = 1.0
+
+    def update_modifier_texts(self) -> None:
+        lines: List[Tuple[str, str]] = []
+        for modifier in self.active_modifiers:
+            info = MODIFIER_DEFINITIONS.get(modifier)
+            if not info:
+                continue
+            name = self.language_manager.get_text(info["name_key"])
+            description = self.language_manager.get_text(info["description_key"])
+            lines.append((name, description))
+        self.modifier_display_lines = lines
+
+    def _update_modifier_effects(self, dt: float) -> None:
+        if "dense_fog" in self.active_modifiers:
+            self.fog_phase = (self.fog_phase + dt * 0.25) % math.tau
+
+        if "express_signals" in self.active_modifiers:
+            if self.express_active:
+                self.express_elapsed += dt
+                if self.express_elapsed >= 3.0:
+                    self.express_active = False
+                    self.express_elapsed = 0.0
+                    if self.express_announced:
+                        self.add_message(self.language_manager.get_text("express_end"), self.theme['secondary'], 0.8)
+                        self.express_announced = False
+            else:
+                self.express_timer += dt
+                if self.express_timer >= self.express_cooldown:
+                    self.express_active = True
+                    self.express_timer = 0.0
+                    self.express_elapsed = 0.0
+                    self.express_cooldown = random.uniform(9.0, 13.0)
+                    self.add_message(self.language_manager.get_text("express_start"), self.theme['accent'], 0.9)
+                    self.express_announced = True
+
+            target_multiplier = 1.45 if self.express_active else 1.0
+            if self.speed_multiplier < target_multiplier:
+                self.speed_multiplier = min(target_multiplier, self.speed_multiplier + dt * 1.2)
+            else:
+                self.speed_multiplier = max(target_multiplier, self.speed_multiplier - dt * 1.2)
+        else:
+            self.speed_multiplier = max(1.0, self.speed_multiplier - dt * 1.2)
+
+    def _draw_fog_if_needed(self, screen: pygame.Surface) -> None:
+        if "dense_fog" not in self.active_modifiers:
+            return
+        fog_surface = pygame.Surface((WIDTH, HEIGHT), pygame.SRCALPHA)
+        lumps = max(3, len(self.fog_offsets))
+        denominator = max(1, lumps - 1)
+        for index, offset in enumerate(self.fog_offsets):
+            wave = self.fog_phase + offset
+            alpha = max(40, min(150, int(100 + 60 * math.sin(wave))))
+            width = 240
+            height = 130
+            center_x = (index / denominator) * WIDTH + math.sin(wave * 0.7) * 80
+            center_y = 190 + math.cos(wave * 0.5) * 25
+            rect = pygame.Rect(int(center_x - width / 2), int(center_y - height / 2), width, height)
+            pygame.draw.ellipse(fog_surface, (255, 255, 255, alpha), rect)
+        screen.blit(fog_surface, (0, 0))
+
+    def render_modifier_badges(self, screen: pygame.Surface, x: int, y: int, max_width: int) -> int:
+        if not self.modifier_display_lines:
+            return y
+        header_font = pygame.font.Font(FONT_PATH, 22)
+        detail_font = pygame.font.Font(FONT_PATH, 18)
+        header_surface = header_font.render(self.language_manager.get_text("modifiers_title"), True, self.theme['text'])
+        screen.blit(header_surface, (x, y))
+        y += header_surface.get_height() + 6
+        for name, description in self.modifier_display_lines:
+            name_surface = detail_font.render(name, True, self.theme['accent'])
+            screen.blit(name_surface, (x, y))
+            y += name_surface.get_height() + 2
+            for line in wrap_text(description, detail_font, max_width):
+                desc_surface = detail_font.render(line, True, self.theme['text'])
+                screen.blit(desc_surface, (x, y))
+                y += desc_surface.get_height() + 2
+            y += 6
+        return y
+
+    def draw_combo_meter(self, screen: pygame.Surface, x: int, y: int, width: int, height: int) -> None:
+        label_font = pygame.font.Font(FONT_PATH, 24)
+        value_font = pygame.font.Font(FONT_PATH, 18)
+        label_surface = label_font.render(self.language_manager.get_text("combo_meter_label"), True, self.theme['text'])
+        screen.blit(label_surface, (x, y))
+        y += label_surface.get_height() + 6
+        bar_rect = pygame.Rect(x, y, width, height)
+        pygame.draw.rect(screen, (*self.theme['button'], 200), bar_rect, border_radius=height // 2)
+        progress_count = self.combo_count % 4
+        if self.combo_count > 0 and progress_count == 0:
+            progress_count = 4
+        progress = progress_count / 4 if progress_count else 0
+        if progress > 0:
+            inner_rect = pygame.Rect(bar_rect.x, bar_rect.y, int(bar_rect.width * progress), bar_rect.height)
+            pygame.draw.rect(screen, self.theme['accent'], inner_rect, border_radius=bar_rect.height // 2)
+        ratio_text = f"{progress_count}/4" if progress_count else "0/4"
+        ratio_surface = value_font.render(ratio_text, True, self.theme['text'])
+        screen.blit(
+            ratio_surface,
+            (
+                bar_rect.centerx - ratio_surface.get_width() // 2,
+                bar_rect.centery - ratio_surface.get_height() // 2,
+            ),
+        )
+
+    def refresh_level_texts(self):
+        name_kwargs = {}
+        desc_kwargs = {}
+        if self.level_config.get("name_key") == "level_endless":
+            name_kwargs["stage"] = self.level
+        if self.level_config.get("description_key") == "level_endless_desc":
+            desc_kwargs["stage"] = self.level
+
+        self.level_name = self.language_manager.get_text(self.level_config["name_key"], **name_kwargs)
+        self.level_description = self.language_manager.get_text(self.level_config["description_key"], **desc_kwargs)
+        self.instruction_text = self.language_manager.get_text("instruction_base")
+        self.update_modifier_texts()
+
+    def update_language(self, language_code: str | None = None) -> None:
+        if language_code:
+            self.language_manager.set_language(language_code)
+        self.refresh_level_texts()
+        if hasattr(self, 'start_button'):
+            self.start_button.text = self.language_manager.get_text("start")
+        if hasattr(self, 'quit_button'):
+            self.quit_button.text = self.language_manager.get_text("quit")
+        if hasattr(self, 'play_again_button'):
+            self.play_again_button.text = self.language_manager.get_text("play_again")
+
+    def get_current_high_score(self) -> int:
+        return self.high_score if self.game_mode == 'campaign' else self.endless_high_score
 
     # Initializes trains
     def initialize_trains(self):
-        self.train_positions = [i * 80 for i in range(self.max_trains)]  # Set train positions
+        self.train_positions = [i * self.train_spacing for i in range(self.max_trains)]  # Set train positions
         self.track_trains = []  # Initialize track trains
         for i in range(self.max_trains):  # Create track trains
-            color = random.choice(TRAIN_COLORS)  # Choose a random color
+            color = random.choice(self.available_colors)  # Choose a random color
+            identifier = COLOR_IDENTIFIERS.get(color, {}).get("symbol", "")
             x = self.train_positions[i]  # Set X position
-            self.track_trains.append(Train(x, 200, color))  # Add train
+            self.track_trains.append(Train(x, 200, color, speed=self.train_speed, identifier=identifier))
 
         self.selection_trains = []  # Initialize selection trains
-        for i, color in enumerate(TRAIN_COLORS):  # Create selection trains
-            self.selection_trains.append(Train(250 + i * 100, 400, color))  # Add train
+        selection_spacing = 120
+        start_x = WIDTH//2 - ((len(self.available_colors) - 1) * selection_spacing)//2
+        for i, color in enumerate(self.available_colors):  # Create selection trains
+            identifier = COLOR_IDENTIFIERS.get(color, {}).get("symbol", "")
+            self.selection_trains.append(Train(start_x + i * selection_spacing, 400, color, identifier=identifier))
 
     # Draws the game
     def draw(self, screen):
         screen.fill(self.theme['background'])  # Fill the screen
-        
+
         if self.state == MENU:  # If the state is MENU
             self.draw_menu(screen)  # Draw the menu
         elif self.state == PLAYING:  # If the state is PLAYING
@@ -705,15 +1524,15 @@ class Game:
     # Draws the menu
     def draw_menu(self, screen):
         title_font = pygame.font.Font(FONT_PATH, 64)  # Set title font
-        title_text = title_font.render("Train Color Matcher", True, self.theme['text'])  # Render title text
+        title_text = title_font.render(self.language_manager.get_text("title"), True, self.theme['text'])  # Render title text
         title_rect = title_text.get_rect(center=(WIDTH//2, HEIGHT//4))  # Get title rectangle
         screen.blit(title_text, title_rect)  # Blit title text
-        
+
         self.start_button.draw(screen)  # Draw start button
         self.quit_button.draw(screen)  # Draw quit button
 
         version_font = pygame.font.Font(FONT_PATH, 16)  # Set version font
-        version_text = version_font.render("v1.1 | Built by dundd - Feb 2025", True, self.theme['text'])  # Render version text
+        version_text = version_font.render("v1.4 | Zenith Update", True, self.theme['text'])  # Render version text
         version_rect = version_text.get_rect(bottomleft=(10, HEIGHT - 10))  # Get version rectangle
         screen.blit(version_text, version_rect)  # Blit version text
 
@@ -721,29 +1540,55 @@ class Game:
     def draw_game(self, screen):
         for layer in self.parallax_layers:  # Draw parallax layers
             layer.draw(screen)
-        
+
         screen.blit(self.background, (0, 0))  # Blit background
-        
-        for i, train in enumerate(self.track_trains):  # Draw track trains
+
+        for train in self.track_trains:  # Draw track trains
             if not train.moving:
-                train.draw(screen)
+                train.draw(screen, False, self.color_blind_mode)
+        self._draw_fog_if_needed(screen)
         for train in self.selection_trains:  # Draw selection trains
-            train.draw(screen)
+            train.draw(screen, False, self.color_blind_mode)
 
         for message in self.messages:  # Draw messages
             message.draw(screen)
 
-        font = pygame.font.Font(FONT_PATH, 36)  # Set font
-        
-        remaining_trains = len(self.track_trains) - self.current_train_index  # Calculate remaining trains
-        progress_text = font.render(f'Remaining Trains: {remaining_trains}', True, self.theme['text'])  # Render progress text
-        score_text = font.render(f'Score: {self.score}', True, self.theme['text'])  # Render score text
-        level_text = font.render(f'Level: {self.level}', True, self.theme['text'])  # Render level text
-        
-        screen.blit(progress_text, (10, 10))  # Blit progress text
-        screen.blit(score_text, (10, 40))  # Blit score text
-        screen.blit(level_text, (10, 70))  # Blit level text
-        
+        info_font = pygame.font.Font(FONT_PATH, 34)  # Set font
+        small_font = pygame.font.Font(FONT_PATH, 24)
+
+        remaining_trains = len(self.track_trains) - self.current_train_index
+        score_text = info_font.render(
+            f"{self.language_manager.get_text('score')}: {self.score}", True, self.theme['text']
+        )
+        remaining_text = info_font.render(
+            f"{self.language_manager.get_text('remaining')}: {remaining_trains}", True, self.theme['text']
+        )
+        mistake_cap = "∞" if self.zen_mode else str(self.max_mistakes)
+        mistakes_text = info_font.render(
+            f"{self.language_manager.get_text('mistakes')}: {self.mistakes}/{mistake_cap}", True, self.theme['text']
+        )
+        level_text = info_font.render(
+            f"{self.language_manager.get_text('level_label')} {self.level}: {self.level_name}", True, self.theme['text']
+        )
+        high_score_value = self.get_current_high_score()
+        high_score_text = info_font.render(
+            f"{self.language_manager.get_text('high_score')}: {high_score_value}", True, self.theme['text']
+        )
+        mode_label = self.language_manager.get_text('mode')
+        active_mode = self.language_manager.get_text(f"mode_{self.game_mode}")
+        mode_text = small_font.render(f"{mode_label}: {active_mode}", True, self.theme['text'])
+        description_text = small_font.render(self.level_description, True, self.theme['text'])
+
+        screen.blit(score_text, (10, 10))
+        screen.blit(remaining_text, (10, 50))
+        screen.blit(mistakes_text, (10, 90))
+        screen.blit(level_text, (10, 130))
+        screen.blit(high_score_text, (10, 170))
+        screen.blit(mode_text, (10, 210))
+        screen.blit(description_text, (10, 240))
+        info_bottom = self.render_modifier_badges(screen, 10, 280, 360)
+        self.draw_combo_meter(screen, 10, info_bottom + 10, 260, 26)
+
         self.mute_button.draw(screen)  # Draw mute button
 
         for particle in self.explosion_particles:  # Draw explosion particles
@@ -752,21 +1597,55 @@ class Game:
         if self.combo_message:  # Draw combo message
             self.combo_message.draw(screen)
 
+        if self.level_intro_timer > 0:
+            banner_font = pygame.font.Font(FONT_PATH, 48)
+            banner_text = self.language_manager.get_text(
+                "new_level", level=self.level, name=self.level_name
+            )
+            text_surface = banner_font.render(banner_text, True, self.theme['text'])
+            banner_surface = pygame.Surface((text_surface.get_width() + 40, text_surface.get_height() + 20), pygame.SRCALPHA)
+            pygame.draw.rect(banner_surface, (*self.theme['button'], 200), banner_surface.get_rect(), border_radius=12)
+            banner_surface.blit(text_surface, (20, 10))
+            screen.blit(
+                banner_surface,
+                (WIDTH//2 - banner_surface.get_width()//2, HEIGHT//6),
+            )
+
     # Draws the game over screen
     def draw_game_over(self, screen):
-        font = pygame.font.Font(FONT_PATH, 64)  # Set font
-        game_over_text = font.render("Game Over!", True, self.theme['text'])  # Render game over text
-        score_text = font.render(f"Final Score: {self.score}", True, self.theme['text'])  # Render score text
-        
-        screen.blit(game_over_text, (WIDTH//2 - 150, HEIGHT//4))  # Blit game over text
-        screen.blit(score_text, (WIDTH//2 - 150, HEIGHT//3))  # Blit score text
-        
-        self.play_again_button.draw(screen)  # Draw play again button
+        title_font = pygame.font.Font(FONT_PATH, 64)
+        body_font = pygame.font.Font(FONT_PATH, 36)
+
+        game_over_text = title_font.render(self.language_manager.get_text("game_over"), True, self.theme['text'])
+        score_text = body_font.render(
+            self.language_manager.get_text("final_score", score=self.score), True, self.theme['text']
+        )
+
+        if self.game_over_reason == 'victory':
+            reason_text = self.language_manager.get_text("reason_victory")
+        elif self.game_over_reason == 'mistakes':
+            reason_text = self.language_manager.get_text("reason_mistakes")
+        else:
+            reason_text = self.language_manager.get_text("reason_quit")
+
+        reason_surface = body_font.render(reason_text, True, self.theme['text'])
+        high_score_surface = body_font.render(
+            f"{self.language_manager.get_text('high_score')}: {self.get_current_high_score()}",
+            True,
+            self.theme['text'],
+        )
+
+        screen.blit(game_over_text, (WIDTH//2 - game_over_text.get_width()//2, HEIGHT//4))
+        screen.blit(score_text, (WIDTH//2 - score_text.get_width()//2, HEIGHT//4 + 80))
+        screen.blit(reason_surface, (WIDTH//2 - reason_surface.get_width()//2, HEIGHT//4 + 140))
+        screen.blit(high_score_surface, (WIDTH//2 - high_score_surface.get_width()//2, HEIGHT//4 + 200))
+
+        self.play_again_button.draw(screen)
 
     # Handles click events
     def handle_click(self, pos):
         if self.mute_button.is_clicked(pos):  # If the mute button is clicked
-            self.sound_manager.muted = not self.sound_manager.muted  # Toggle mute state
+            self.sound_manager.toggle_mute()
             self.mute_button.text = "🔊" if not self.sound_manager.muted else "🔈"  # Update mute button text
             return True
 
@@ -777,38 +1656,25 @@ class Game:
                 self.state = PLAYING  # Set state to PLAYING
                 self.reset_game()  # Reset the game
             elif self.quit_button.is_clicked(pos):  # If the quit button is clicked
+                self.game_over_reason = 'quit'
                 return False
-                
+
         elif self.state == PLAYING:  # If the state is PLAYING
             clicked = False
             for selection_train in self.selection_trains:  # Check if a selection train is clicked
                 if (selection_train.x < pos[0] < selection_train.x + selection_train.width and
                     selection_train.y < pos[1] < pos[1] < selection_train.y + selection_train.height):
                     clicked = True
-                    
+
                     if self.current_train_index < len(self.track_trains):  # If there are remaining track trains
                         current_train = self.track_trains[self.current_train_index]
-                        
+
                         if selection_train.color == current_train.color:  # If the colors match
-                            self.sound_manager.play('correct')  # Play correct sound
-                            self.create_explosion(current_train.x, current_train.y, current_train.color)  # Create explosion
-                            current_train.moving = True  # Set train to moving
-                            current_train.move_direction = "left"  # Set move direction to left
-                            self.score += 1  # Increment score
-                            self.add_message("Correct!", self.theme['secondary'])  # Add correct message
-                            self.current_train_index += 1  # Increment current train index
-                            self.combo_count += 1  # Increment combo count
-                            self.update_combo_message()  # Update combo message
-                            self.sound_manager.play('item_pickup')  # Play item pickup sound
-                            if self.current_train_index >= len(self.track_trains):  # If all track trains are matched
-                                self.all_trains_moving = True  # Set all trains moving state to True
+                            self.on_correct_match(current_train)
                         else:
-                            self.sound_manager.play('wrong')  # Play wrong sound
-                            self.add_message("Wrong Color!", self.theme['error'])  # Add wrong color message
-                            self.combo_count = 0  # Reset combo count
-                            self.combo_message = None  # Reset combo message
+                            self.on_wrong_match()
             if not clicked:
-                self.add_message("Please click on a train!", self.theme['accent'], 0.5)  # Add click on train message
+                self.add_message(self.language_manager.get_text("message_click_train"), self.theme['accent'], 0.5)
 
         elif self.state == GAME_OVER:  # If the state is GAME_OVER
             if self.play_again_button.is_clicked(pos):  # If the play again button is clicked
@@ -816,6 +1682,9 @@ class Game:
                 self.state = PLAYING  # Set state to PLAYING
                 self.reset_game()  # Reset the game
             elif self.quit_button.is_clicked(pos):  # If the quit button is clicked
+                self.game_over_reason = 'quit'
+                if getattr(self.sound_manager, 'available', False):
+                    self.sound_manager.play_music('menu')
                 return False
         return True
 
@@ -826,20 +1695,22 @@ class Game:
             dt = (current_time - self.last_time) / 1000.0  # Calculate delta time
             self.last_time = current_time  # Update last time
 
+            self._update_modifier_effects(dt)
+
             for layer in self.parallax_layers:  # Update parallax layers
                 layer.update(dt)
 
+            if self.level_intro_timer > 0:
+                self.level_intro_timer = max(0, self.level_intro_timer - dt)
+
             for train in self.track_trains:  # Update track trains
                 if train.moving:
+                    train.speed = self.train_speed * self.speed_multiplier
                     train.move()
 
-            if self.all_trains_moving and all(not train.moving for train in self.track_trains):  # If all trains are moving and stopped
-                self.state = GAME_OVER  # Set state to GAME_OVER
-                self.high_score = max(self.high_score, self.score)  # Update high score
-                self.sound_manager.play('game_over')  # Play game over sound
-
-            if self.score >= self.level * self.level_up_threshold:  # If the score meets the level up threshold
-                self.level_up()  # Level up
+            if self.all_trains_moving and all(not train.moving for train in self.track_trains):
+                self.all_trains_moving = False
+                self.handle_level_completion()
 
             for message in self.messages:  # Update messages
                 message.update(dt)
@@ -854,17 +1725,110 @@ class Game:
                 if self.combo_message.should_remove():
                     self.combo_message = None
 
-    # Levels up the game
-    def level_up(self):
-        self.level += 1  # Increment level
-        self.sound_manager.play('level_up')  # Play level up sound
-        self.add_message(f"Level Up! {self.level}", self.theme['primary'], 1.5)  # Add level up message
-        self.train_speed += 1  # Increment train speed
-        self.max_trains += 2  # Increment max trains
-        self.train_positions = [i * 80 for i in range(self.max_trains)]  # Set train positions
-        self.initialize_trains()  # Initialize trains
-        self.sound_manager.play('victory')  # Play victory sound
-        self.max_trains = min(self.max_trains, 15)  # Cap max trains
+    def on_correct_match(self, current_train: Train) -> None:
+        self.sound_manager.play('correct')
+        self.create_explosion(current_train.x, current_train.y, current_train.color)
+        current_train.moving = True
+        current_train.move_direction = "left"
+        current_train.speed = self.train_speed
+        self.score += 1
+        self.add_message(self.language_manager.get_text("message_correct"), self.theme['secondary'])
+        self.current_train_index += 1
+        self.combo_count += 1
+        self.update_combo_message()
+        self.sound_manager.play('item_pickup')
+        if self.combo_count % 4 == 0 and self.mistakes > 0:
+            self.mistakes -= 1
+            self.sound_manager.play('recovery')
+            self.add_message(
+                self.language_manager.get_text('mistake_recovered'),
+                self.theme['secondary'],
+                0.9,
+            )
+        if self.current_train_index >= len(self.track_trains):
+            self.all_trains_moving = True
+
+    def on_wrong_match(self) -> None:
+        self.sound_manager.play('wrong')
+        self.add_message(self.language_manager.get_text("message_wrong"), self.theme['error'])
+        self.combo_count = 0
+        self.combo_message = None
+        self.mistakes += 1
+        if self.zen_mode:
+            self.add_message(self.language_manager.get_text("zen_reminder"), self.theme['secondary'], 0.6)
+            return
+        if self.mistakes >= self.max_mistakes:
+            self.state = GAME_OVER
+            self.game_over_reason = 'mistakes'
+            if self.game_mode == 'endless':
+                self.endless_high_score = max(self.endless_high_score, self.score)
+            else:
+                self.high_score = max(self.high_score, self.score)
+            self.sound_manager.play('game_over_sting')
+            if getattr(self.sound_manager, 'available', False):
+                self.sound_manager.play_music('game_over', loop=False)
+
+    def handle_level_completion(self):
+        if self.game_mode == 'endless':
+            self.endless_stage += 1
+            self.level = self.endless_stage + 1
+            previous_mistakes = self.mistakes
+            self.mistakes = max(0, self.mistakes - 1)
+            self.combo_count = 0
+            self.combo_message = None
+            self.level_index = min(self.endless_stage, len(LEVEL_CONFIGS) - 1)
+            previous_modifiers = set(self.active_modifiers)
+            self.apply_level_rules()
+            self.initialize_trains()
+            self.level_intro_timer = 2.5
+            banner = self.language_manager.get_text('new_level', level=self.level, name=self.level_name)
+            self.add_message(banner, self.theme['accent'], 1.5)
+            if self.mistakes < previous_mistakes:
+                self.add_message(
+                    self.language_manager.get_text('mistake_recovered'),
+                    self.theme['secondary'],
+                    0.8,
+                )
+            new_modifiers = set(self.active_modifiers) - previous_modifiers
+            for modifier in new_modifiers:
+                info = MODIFIER_DEFINITIONS.get(modifier)
+                if info:
+                    name = self.language_manager.get_text(info["name_key"])
+                    self.add_message(name, self.theme['accent'], 1.2)
+            self.sound_manager.play('level_up')
+            if getattr(self.sound_manager, 'available', False):
+                self.sound_manager.play_music('endless')
+        else:
+            if self.level_index < len(LEVEL_CONFIGS) - 1:
+                self.level_index += 1
+                self.level = self.level_index + 1
+                self.mistakes = 0
+                self.combo_count = 0
+                self.combo_message = None
+                previous_modifiers = set(self.active_modifiers)
+                self.apply_level_rules()
+                self.initialize_trains()
+                self.level_intro_timer = 2.5
+                self.add_message(
+                    self.language_manager.get_text('new_level', level=self.level, name=self.level_name),
+                    self.theme['accent'],
+                    1.5,
+                )
+                new_modifiers = set(self.active_modifiers) - previous_modifiers
+                for modifier in new_modifiers:
+                    info = MODIFIER_DEFINITIONS.get(modifier)
+                    if info:
+                        name = self.language_manager.get_text(info["name_key"])
+                        self.add_message(name, self.theme['accent'], 1.2)
+                self.sound_manager.play('level_up')
+            else:
+                self.state = GAME_OVER
+                self.game_over_reason = 'victory'
+                self.high_score = max(self.high_score, self.score)
+                self.sound_manager.play('victory')
+                if getattr(self.sound_manager, 'available', False):
+                    self.sound_manager.play_music('victory_theme', loop=False)
+                self.add_message(self.language_manager.get_text('victory_banner'), self.theme['secondary'], 2.0)
 
     # Creates an explosion
     def create_explosion(self, x, y, color):
@@ -928,228 +1892,531 @@ class Star:
         pygame.draw.circle(screen, color, (self.x, self.y), self.size)  # Draw the star
 
 # Modern game class with additional features
+
 class ModernGame(Game):
-    # Initializes the modern game
+    """Modern presentation layer with enhanced UI, settings, and language support."""
+
     def __init__(self):
-        self.theme = LIGHT_THEME  # Set theme to light theme
-        super().__init__()  # Call superclass constructor
-        self.dark_mode = False  # Set dark mode to False
-        self.theme = LIGHT_THEME  # Set theme to light theme
-        self.transition_alpha = 255  # Set transition alpha
-        self.particles = []  # Initialize particles
-        self.create_modern_buttons()  # Create modern buttons
-        self.theme_button = ModernButton(WIDTH - 100, 10, 80, 40, "DARK", self.theme['button'], self.theme, self.sound_manager)  # Create theme button
-        self.all_trains_moving = False  # Set all trains moving state to False
-        self.instruction_text = "Match the trains starting from the left!"  # Set instruction text
-        self.instruction_font = pygame.font.Font(FONT_PATH, 36)  # Set instruction font
-        self.trees = [Tree(random.randint(50, WIDTH - 50), HEIGHT - 100) for _ in range(TREE_COUNT)]  # Create trees
-        self.clouds = [Cloud(random.randint(0, WIDTH), random.randint(*CLOUD_HEIGHT_RANGE)) for _ in range(CLOUD_COUNT)]  # Create clouds
-        self.stars = [Star(random.randint(0, WIDTH), random.randint(0, HEIGHT // 2)) for _ in range(STAR_COUNT)]  # Create stars
-        self.transitioning = False  # Set transitioning state to False
-        self.transition_alpha = 0  # Set transition alpha
-        self.selected_train_index = 0  # Set selected train index
+        self.theme = LIGHT_THEME  # Ensure theme exists before base init
+        self.language_manager = LanguageManager()
+        super().__init__(language_manager=self.language_manager)
+        self.dark_mode = False
+        self.transitioning = False
+        self.transition_alpha = 0
+        self.particles: List[Particle] = []
+        self.selected_train_index = 0
+        self.instruction_font = pygame.font.Font(FONT_PATH, 32)
+        self.difficulty_modes = ["standard", "relaxed", "expert"]
+        self.difficulty_mode_index = 0
+        self.difficulty_mode = self.difficulty_modes[self.difficulty_mode_index]
+        self.trees = [Tree(random.randint(50, WIDTH - 50), HEIGHT - 100) for _ in range(TREE_COUNT)]
+        self.clouds = [Cloud(random.randint(0, WIDTH), random.randint(*CLOUD_HEIGHT_RANGE)) for _ in range(CLOUD_COUNT)]
+        self.stars = [Star(random.randint(0, WIDTH), random.randint(0, HEIGHT // 2)) for _ in range(STAR_COUNT)]
+
+        self.create_modern_buttons()
+        self.theme_button = ModernButton(
+            WIDTH - 120,
+            10,
+            100,
+            40,
+            "DARK",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+        self.settings_button = ModernButton(
+            WIDTH - 240,
+            10,
+            110,
+            40,
+            self.language_manager.get_text("settings"),
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+
+        self.show_settings = False
+        panel_width, panel_height = 420, 430
+        self.settings_panel_rect = pygame.Rect(
+            WIDTH // 2 - panel_width // 2,
+            HEIGHT // 2 - panel_height // 2,
+            panel_width,
+            panel_height,
+        )
+        self.create_settings_buttons()
+        self.update_settings_texts()
+        self.update_button_styles()
+
         try:
             self.parallax_layers = [
                 ParallaxLayer(
                     os.path.join(IMAGES_DIR, "cloud_layer.png"),
                     CONFIG["parallax"]["cloud_speed"],
-                    CONFIG["parallax"]["cloud_offset_y"]
+                    CONFIG["parallax"]["cloud_offset_y"],
                 ),
                 ParallaxLayer(
                     os.path.join(IMAGES_DIR, "tree_layer.png"),
                     CONFIG["parallax"]["tree_speed"],
-                    CONFIG["parallax"]["tree_offset_y"]
-                )
+                    CONFIG["parallax"]["tree_offset_y"],
+                ),
             ]
         except KeyError as e:
             print(f"Warning: Missing parallax configuration: {e}")
             self.parallax_layers = []
 
-    # Handles keyboard input
-    def handle_keyboard_input(self, event):
-        if self.state == PLAYING:  # If the state is PLAYING
-            if event.key == pygame.K_LEFT:  # If the left arrow key is pressed
-                self.selected_train_index = (self.selected_train_index - 1) % len(self.selection_trains)  # Decrement selected train index
-            elif event.key == pygame.K_RIGHT:  # If the right arrow key is pressed
-                self.selected_train_index = (self.selected_train_index + 1) % len(self.selection_trains)  # Increment selected train index
-            elif event.key == pygame.K_SPACE or event.key == pygame.K_RETURN:  # If the space or enter key is pressed
-                self.match_train()  # Match train
-
-    # Matches the selected train with the current track train
-    def match_train(self):
-        if self.current_train_index < len(self.track_trains):  # If there are remaining track trains
-            selected_train = self.selection_trains[self.selected_train_index]  # Get selected train
-            current_train = self.track_trains[self.current_train_index]  # Get current track train
-
-            if selected_train.color == current_train.color:  # If the colors match
-                self.sound_manager.play('correct')  # Play correct sound
-                current_train.moving = True  # Set train to moving
-                current_train.move_direction = "left"  # Set move direction to left
-                self.score += 1  # Increment score
-                self.add_message("Correct!", self.theme['secondary'])  # Add correct message
-                self.current_train_index += 1  # Increment current train index
-
-                if self.current_train_index >= len(self.track_trains):  # If all track trains are matched
-                    self.all_trains_moving = True  # Set all trains moving state to True
-            else:
-                self.sound_manager.play('wrong')  # Play wrong sound
-                self.add_message("Wrong Color!", self.theme['error'])  # Add wrong color message
-        else:
-            self.add_message("No more trains to match!", self.theme['accent'], 0.5)  # Add no more trains message
-
-    # Starts the theme transition
-    def start_transition(self):
-        self.transitioning = True  # Set transitioning state to True
-        self.transition_alpha = 0  # Set transition alpha
-
-    # Toggles the theme
-    def toggle_theme(self):
-        self.start_transition()  # Start transition
-
-    # Creates the background
-    def create_background(self):
-        self.background.fill(self.theme['background'])  # Fill the background
-        for x in range(0, WIDTH, 30):  # Draw the track
-            pygame.draw.rect(self.background, self.theme['track'], (x, 240, 20, 20))
-        pygame.draw.line(self.background, self.theme['text'], (0, 235), (WIDTH, 235), 5)  # Draw the rails
-        pygame.draw.line(self.background, self.theme['text'], (0, 265), (WIDTH, 265), 5)
-
-    # Draws the game
-    def draw_game(self, screen):
-        screen.blit(self.background, (0, 0))  # Blit background
-        
-        if self.dark_mode:  # If dark mode is enabled
-            for star in self.stars:  # Draw stars
-                star.draw(screen)
-
-        for tree in self.trees:  # Draw trees
-            tree.draw(screen)
-
-        for cloud in self.clouds:  # Draw clouds
-            cloud.draw(screen)
-        
-        for train in self.track_trains + self.selection_trains:  # Draw trains
-            train.draw(screen, self.dark_mode)
-
-        selection_train = self.selection_trains[self.selected_train_index]  # Get selected train
-        pygame.draw.rect(screen, YELLOW, (selection_train.x - 5, selection_train.y - 5,
-                                            selection_train.width + 10, selection_train.height + 10), 3)  # Draw selection rectangle
-
-        for message in self.messages:  # Draw messages
-            message.draw(screen)
-
-        font = pygame.font.Font(None, 36)  # Set font
-        
-        score_text = font.render(f'Score: {self.score}', True, self.theme['text'])  # Render score text
-        remaining_trains = len(self.track_trains) - self.current_train_index  # Calculate remaining trains
-        progress_text = font.render(f'Remaining: {remaining_trains}', True, self.theme['text'])  # Render progress text
-        high_score_text = font.render(f'High Score: {self.high_score}', True, self.theme['text'])  # Render high score text
-        
-        screen.blit(score_text, (20, 20))  # Blit score text
-        screen.blit(progress_text, (20, 60))  # Blit progress text
-        screen.blit(high_score_text, (20, 100))  # Blit high score text
-        
-        instruction_surface = self.instruction_font.render(
-            self.instruction_text, True, self.theme['text'])  # Render instruction text
-        instruction_bg = pygame.Surface((instruction_surface.get_width() + 20, 40))  # Create instruction background
-        instruction_bg.fill(self.theme['button'])  # Fill instruction background
-        instruction_bg.set_alpha(200)  # Set instruction background alpha
-        screen.blit(instruction_bg, 
-                   (WIDTH//2 - instruction_bg.get_width()//2, HEIGHT - 60))  # Blit instruction background
-        screen.blit(instruction_surface, 
-                   (WIDTH//2 - instruction_surface.get_width()//2, HEIGHT - 50))  # Blit instruction text
-        
-        self.mute_button.draw(screen)  # Draw mute button
-        self.theme_button.draw(screen)  # Draw theme button
-
-        if self.transitioning:  # If transitioning
-            transition_surface = pygame.Surface((WIDTH, HEIGHT))  # Create transition surface
-            transition_surface.fill(self.theme['background'])  # Fill transition surface
-            transition_surface.set_alpha(self.transition_alpha)  # Set transition surface alpha
-            screen.blit(transition_surface, (0, 0))  # Blit transition surface
-
-    # Handles click events
-    def handle_click(self, pos):
-        if self.theme_button.is_clicked(pos):  # If the theme button is clicked
-            self.toggle_theme()  # Toggle theme
-            self.sound_manager.play('click')  # Play click sound
-            return True
-
-        if self.state == MENU:  # If the state is MENU
-            if self.start_button.is_clicked(pos):  # If the start button is clicked
-                self.start_button.create_particles()  # Create particles
-                self.sound_manager.play('click')  # Play click sound
-                self.state = PLAYING  # Set state to PLAYING
-                self.reset_game()  # Reset the game
-            elif self.quit_button.is_clicked(pos):  # If the quit button is clicked
-                return False
-                
-        elif self.state == PLAYING:  # If the state is PLAYING
-            clicked = False
-            for i, selection_train in enumerate(self.selection_trains):  # Check if a selection train is clicked
-                if (selection_train.x < pos[0] < selection_train.x + selection_train.width and
-                    selection_train.y < pos[1] < selection_train.y + selection_train.height):
-                    clicked = True
-                    self.selected_train_index = i  # Set selected train index
-                    self.match_train()  # Match train
-                    break
-            if not clicked:
-                self.add_message("Please click on a train!", self.theme['accent'], 0.5)  # Add click on train message
-
-        elif self.state == GAME_OVER:  # If the state is GAME_OVER
-            if self.play_again_button.is_clicked(pos):  # If the play again button is clicked
-                self.sound_manager.play('click')  # Play click sound
-                self.state = PLAYING  # Set state to PLAYING
-                self.reset_game()  # Reset the game
-            elif self.quit_button.is_clicked(pos):  # If the quit button is clicked
-                return False
-        return True
-
-    # Updates the game
-    def update(self, dt: float) -> None:
-        super().update()  # Call superclass update method
-        for cloud in self.clouds:  # Update clouds
-            cloud.update(dt)
-
-        for button in [self.start_button, self.quit_button, self.play_again_button, self.theme_button]:  # Update buttons
-            button.update(dt)
-
-        if self.transitioning:  # If transitioning
-            self.transition_alpha += TRANSITION_SPEED * dt  # Update transition alpha
-            if self.transition_alpha >= 255:  # If transition is complete
-                self.complete_transition()  # Complete transition
-
-        for train in self.track_trains:  # Update track trains
-            train.move()
-
-        for message in self.messages:  # Update messages
-            message.update(dt)
-        self.messages = [msg for msg in self.messages if not msg.should_remove()]  # Remove old messages
-
-    # Creates modern buttons
     def create_modern_buttons(self):
         self.start_button = ModernButton(
-            WIDTH//2 - 100, HEIGHT//2 - 50, 200, 50,
-            "Start Game", self.theme['primary'], self.theme, self.sound_manager
+            WIDTH//2 - 140,
+            HEIGHT//2,
+            280,
+            60,
+            self.language_manager.get_text("start"),
+            self.theme['primary'],
+            self.theme,
+            self.sound_manager,
         )
         self.quit_button = ModernButton(
-            WIDTH//2 - 100, HEIGHT//2 + 50, 200, 50,
-            "Quit", self.theme['error'], self.theme, self.sound_manager
+            WIDTH//2 - 140,
+            HEIGHT//2 + 80,
+            280,
+            60,
+            self.language_manager.get_text("quit"),
+            self.theme['error'],
+            self.theme,
+            self.sound_manager,
         )
         self.play_again_button = ModernButton(
-            WIDTH//2 - 100, HEIGHT//2 + 50, 200, 50,
-            "Play Again", self.theme['primary'], self.theme, self.sound_manager
+            WIDTH//2 - 140,
+            HEIGHT//2 + 80,
+            280,
+            60,
+            self.language_manager.get_text("play_again"),
+            self.theme['primary'],
+            self.theme,
+            self.sound_manager,
         )
 
+    def create_settings_buttons(self):
+        btn_width = self.settings_panel_rect.width - 60
+        base_x = self.settings_panel_rect.x + 30
+        base_y = self.settings_panel_rect.y + 90
+        self.language_button = ModernButton(
+            base_x,
+            base_y,
+            btn_width,
+            50,
+            "",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+        self.difficulty_button = ModernButton(
+            base_x,
+            base_y + 70,
+            btn_width,
+            50,
+            "",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+        self.symbols_button = ModernButton(
+            base_x,
+            base_y + 140,
+            btn_width,
+            50,
+            "",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+        self.mode_button = ModernButton(
+            base_x,
+            base_y + 210,
+            btn_width,
+            50,
+            "",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+        self.zen_button = ModernButton(
+            base_x,
+            base_y + 280,
+            btn_width,
+            50,
+            "",
+            self.theme['button'],
+            self.theme,
+            self.sound_manager,
+        )
+
+    def reset_game(self):
+        super().reset_game()
+        self.show_settings = False
+        if hasattr(self, 'language_button'):
+            self.update_settings_texts()
+
+    def update_settings_texts(self):
+        language_label = f"{self.language_manager.get_text('language')}: {self.language_manager.get_language_label()}"
+        difficulty_key = f"difficulty_{self.difficulty_modes[self.difficulty_mode_index]}"
+        difficulty_label = f"{self.language_manager.get_text('difficulty')}: {self.language_manager.get_text(difficulty_key)}"
+        symbols_state = (
+            self.language_manager.get_text('color_mode_on')
+            if self.color_blind_mode
+            else self.language_manager.get_text('color_mode_off')
+        )
+        symbols_label = f"{self.language_manager.get_text('color_mode')}: {symbols_state}"
+        mode_label = f"{self.language_manager.get_text('mode')}: {self.language_manager.get_text(f'mode_{self.game_mode}')}"
+        zen_state = (
+            self.language_manager.get_text('zen_mode_on')
+            if self.zen_mode
+            else self.language_manager.get_text('zen_mode_off')
+        )
+        zen_label = f"{self.language_manager.get_text('zen_mode')}: {zen_state}"
+
+        self.language_button.text = language_label
+        self.difficulty_button.text = difficulty_label
+        self.symbols_button.text = symbols_label
+        self.mode_button.text = mode_label
+        self.zen_button.text = zen_label
+
+    def update_button_styles(self):
+        for button in [self.start_button, self.play_again_button]:
+            button.color = self.theme['primary']
+            button.theme = self.theme
+        self.quit_button.color = self.theme['error']
+        self.quit_button.theme = self.theme
+        self.theme_button.color = self.theme['button']
+        self.theme_button.theme = self.theme
+        self.settings_button.color = self.theme['button']
+        self.settings_button.theme = self.theme
+        for button in [self.language_button, self.difficulty_button, self.symbols_button, self.mode_button, self.zen_button]:
+            button.color = self.theme['button']
+            button.theme = self.theme
+
+    def update_language(self, language_code: str | None = None) -> None:
+        super().update_language(language_code)
+        self.settings_button.text = self.language_manager.get_text("settings")
+        self.start_button.text = self.language_manager.get_text("start")
+        self.quit_button.text = self.language_manager.get_text("quit")
+        self.play_again_button.text = self.language_manager.get_text("play_again")
+        self.update_settings_texts()
+
+    def cycle_language(self):
+        self.language_manager.cycle_language()
+        self.update_language()
+
+    def cycle_difficulty(self):
+        self.difficulty_mode_index = (self.difficulty_mode_index + 1) % len(self.difficulty_modes)
+        self.difficulty_mode = self.difficulty_modes[self.difficulty_mode_index]
+        modifiers = {"standard": 0, "relaxed": 1, "expert": -1}
+        self.additional_mistakes = modifiers.get(self.difficulty_mode, 0)
+        self.update_mistake_limits(self.base_level_mistakes)
+        self.update_settings_texts()
+        diff_label = self.language_manager.get_text(f"difficulty_{self.difficulty_mode}")
+        self.add_message(diff_label, self.theme['accent'], 0.6)
+
+    def toggle_symbols(self):
+        self.color_blind_mode = not self.color_blind_mode
+        self.update_settings_texts()
+        message_key = 'color_mode_on' if self.color_blind_mode else 'color_mode_off'
+        self.add_message(self.language_manager.get_text(message_key), self.theme['accent'], 0.6)
+
+    def toggle_zen_mode(self):
+        self.zen_mode = not self.zen_mode
+        self.update_mistake_limits(self.base_level_mistakes)
+        self.update_settings_texts()
+        if self.zen_mode:
+            message = self.language_manager.get_text('zen_hint')
+            color = self.theme['secondary']
+        else:
+            message = self.language_manager.get_text('zen_mode_off')
+            color = self.theme['accent']
+        self.add_message(message, color, 0.8)
+        if self.zen_mode and self.state == PLAYING:
+            self.add_message(self.language_manager.get_text('zen_reminder'), self.theme['secondary'], 0.6)
+
+    def cycle_mode(self):
+        current_index = self.available_modes.index(self.game_mode)
+        self.game_mode = self.available_modes[(current_index + 1) % len(self.available_modes)]
+        mode_label = self.language_manager.get_text(f"mode_{self.game_mode}")
+        self.update_settings_texts()
+        self.state = MENU
+        self.reset_game()
+        if getattr(self.sound_manager, 'available', False):
+            self.sound_manager.play_music('menu')
+        self.add_message(
+            self.language_manager.get_text('mode_switch_warning', mode=mode_label),
+            self.theme['accent'],
+            1.0,
+        )
+
+    def handle_keyboard_input(self, event):
+        if self.state == PLAYING:
+            if event.key == pygame.K_LEFT:
+                self.selected_train_index = (self.selected_train_index - 1) % len(self.selection_trains)
+            elif event.key == pygame.K_RIGHT:
+                self.selected_train_index = (self.selected_train_index + 1) % len(self.selection_trains)
+            elif event.key in (pygame.K_SPACE, pygame.K_RETURN):
+                self.match_train()
+
+    def match_train(self):
+        if self.current_train_index < len(self.track_trains):
+            selected_train = self.selection_trains[self.selected_train_index]
+            current_train = self.track_trains[self.current_train_index]
+            if selected_train.color == current_train.color:
+                self.on_correct_match(current_train)
+            else:
+                self.on_wrong_match()
+        else:
+            self.add_message(self.language_manager.get_text("message_no_trains"), self.theme['accent'], 0.5)
+
+    def start_transition(self):
+        self.transitioning = True
+        self.transition_alpha = 0
+
+    def toggle_theme(self):
+        self.start_transition()
+
+    def create_background(self):
+        self.background.fill(self.theme['background'])
+        for x in range(0, WIDTH, 30):
+            pygame.draw.rect(self.background, self.theme['track'], (x, RAILROAD_HEIGHT, 20, 20))
+        rail_color = self.theme.get('rail_color', self.theme['text'])
+        pygame.draw.line(self.background, rail_color, (0, RAILROAD_HEIGHT - 5), (WIDTH, RAILROAD_HEIGHT - 5), RAIL_THICKNESS)
+        pygame.draw.line(self.background, rail_color, (0, RAILROAD_HEIGHT + 25), (WIDTH, RAILROAD_HEIGHT + 25), RAIL_THICKNESS)
+
+    def draw_menu(self, screen):
+        screen.blit(self.background, (0, 0))
+        title_font = pygame.font.Font(FONT_PATH, 72)
+        subtitle_font = pygame.font.Font(FONT_PATH, 32)
+        title_text = title_font.render(self.language_manager.get_text("title"), True, self.theme['text'])
+        screen.blit(title_text, (WIDTH//2 - title_text.get_width()//2, HEIGHT//4 - 40))
+
+        subtitle = subtitle_font.render(self.level_description, True, self.theme['text'])
+        screen.blit(subtitle, (WIDTH//2 - subtitle.get_width()//2, HEIGHT//4 + 20))
+
+        self.start_button.draw(screen)
+        self.quit_button.draw(screen)
+        self.settings_button.draw(screen)
+
+        info_font = pygame.font.Font(FONT_PATH, 24)
+        difficulty_key = f"difficulty_{self.difficulty_modes[self.difficulty_mode_index]}"
+        difficulty_text = info_font.render(
+            f"{self.language_manager.get_text('difficulty')}: {self.language_manager.get_text(difficulty_key)}",
+            True,
+            self.theme['text'],
+        )
+        language_text = info_font.render(
+            f"{self.language_manager.get_text('language')}: {self.language_manager.get_language_label()}",
+            True,
+            self.theme['text'],
+        )
+        mode_text = info_font.render(
+            f"{self.language_manager.get_text('mode')}: {self.language_manager.get_text(f'mode_{self.game_mode}')}",
+            True,
+            self.theme['text'],
+        )
+        screen.blit(difficulty_text, (WIDTH//2 - difficulty_text.get_width()//2, HEIGHT//2 + 170))
+        screen.blit(language_text, (WIDTH//2 - language_text.get_width()//2, HEIGHT//2 + 200))
+        screen.blit(mode_text, (WIDTH//2 - mode_text.get_width()//2, HEIGHT//2 + 230))
+
+        version_font = pygame.font.Font(FONT_PATH, 16)
+        version_text = version_font.render("v1.4 | Zenith Update", True, self.theme['text'])
+        screen.blit(version_text, (10, HEIGHT - 30))
+
+        if self.show_settings:
+            self.draw_settings_panel(screen)
+
+    def draw_settings_panel(self, screen):
+        overlay = pygame.Surface((WIDTH, HEIGHT), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 140))
+        screen.blit(overlay, (0, 0))
+
+        panel_surface = pygame.Surface((self.settings_panel_rect.width, self.settings_panel_rect.height), pygame.SRCALPHA)
+        pygame.draw.rect(panel_surface, (*self.theme['button'], 235), panel_surface.get_rect(), border_radius=16)
+        title_font = pygame.font.Font(FONT_PATH, 36)
+        title_text = title_font.render(self.language_manager.get_text("settings_title"), True, self.theme['text'])
+        panel_surface.blit(title_text, (panel_surface.get_width()//2 - title_text.get_width()//2, 20))
+        screen.blit(panel_surface, self.settings_panel_rect.topleft)
+
+        for button in [
+            self.language_button,
+            self.difficulty_button,
+            self.symbols_button,
+            self.mode_button,
+            self.zen_button,
+        ]:
+            button.draw(screen)
+
+    def draw_game(self, screen):
+        for layer in self.parallax_layers:
+            layer.draw(screen)
+        screen.blit(self.background, (0, 0))
+
+        if self.dark_mode:
+            for star in self.stars:
+                star.draw(screen)
+        else:
+            for cloud in self.clouds:
+                cloud.draw(screen)
+
+        for tree in self.trees:
+            tree.draw(screen)
+
+        for train in self.track_trains:
+            if not train.moving:
+                train.draw(screen, self.dark_mode, self.color_blind_mode)
+        self._draw_fog_if_needed(screen)
+        for train in self.selection_trains:
+            train.draw(screen, self.dark_mode, self.color_blind_mode)
+
+        selection_train = self.selection_trains[self.selected_train_index]
+        pygame.draw.rect(
+            screen,
+            self.theme['accent'],
+            (selection_train.x - 8, selection_train.y - 8, selection_train.width + 16, selection_train.height + 16),
+            3,
+        )
+
+        for message in self.messages:
+            message.draw(screen)
+
+        info_font = pygame.font.Font(FONT_PATH, 30)
+        small_font = pygame.font.Font(FONT_PATH, 22)
+        panel_height = 340 + len(self.modifier_display_lines) * 70
+        panel = pygame.Surface((320, panel_height), pygame.SRCALPHA)
+        pygame.draw.rect(panel, (*self.theme['button'], 210), panel.get_rect(), border_radius=16)
+        lines = [
+            f"{self.language_manager.get_text('score')}: {self.score}",
+            f"{self.language_manager.get_text('remaining')}: {len(self.track_trains) - self.current_train_index}",
+            f"{self.language_manager.get_text('mistakes')}: {self.mistakes}/{('∞' if self.zen_mode else self.max_mistakes)}",
+            f"{self.language_manager.get_text('level_label')} {self.level}: {self.level_name}",
+            f"{self.language_manager.get_text('high_score')}: {self.get_current_high_score()}",
+        ]
+        for idx, line in enumerate(lines):
+            text_surface = info_font.render(line, True, self.theme['text'])
+            panel.blit(text_surface, (16, 16 + idx * 34))
+
+        diff_label = f"{self.language_manager.get_text('difficulty')}: {self.language_manager.get_text(f'difficulty_{self.difficulty_mode}')}"
+        lang_label = f"{self.language_manager.get_text('language')}: {self.language_manager.get_language_label()}"
+        label_y = 16 + len(lines) * 34
+        panel.blit(small_font.render(diff_label, True, self.theme['text']), (16, label_y))
+        panel.blit(small_font.render(lang_label, True, self.theme['text']), (16, label_y + 28))
+        badges_bottom = self.render_modifier_badges(panel, 16, label_y + 60, panel.get_width() - 32)
+        self.draw_combo_meter(panel, 16, badges_bottom + 10, panel.get_width() - 32, 24)
+        screen.blit(panel, (WIDTH - panel.get_width() - 20, 20))
+
+        instruction_surface = self.instruction_font.render(self.instruction_text, True, self.theme['text'])
+        instruction_bg = pygame.Surface((instruction_surface.get_width() + 50, 60), pygame.SRCALPHA)
+        pygame.draw.rect(instruction_bg, (*self.theme['button'], 220), instruction_bg.get_rect(), border_radius=24)
+        instruction_bg.blit(instruction_surface, (25, 18))
+        screen.blit(instruction_bg, (WIDTH//2 - instruction_bg.get_width()//2, HEIGHT - 90))
+
+        self.mute_button.draw(screen)
+        self.theme_button.draw(screen)
+        self.settings_button.draw(screen)
+
+        for particle in self.explosion_particles:
+            particle.draw(screen)
+
+        if self.combo_message:
+            self.combo_message.draw(screen)
+
+        if self.level_intro_timer > 0:
+            banner_font = pygame.font.Font(FONT_PATH, 48)
+            banner_text = self.language_manager.get_text("new_level", level=self.level, name=self.level_name)
+            text_surface = banner_font.render(banner_text, True, self.theme['text'])
+            banner_surface = pygame.Surface((text_surface.get_width() + 40, text_surface.get_height() + 20), pygame.SRCALPHA)
+            pygame.draw.rect(banner_surface, (*self.theme['button'], 200), banner_surface.get_rect(), border_radius=12)
+            banner_surface.blit(text_surface, (20, 10))
+            screen.blit(banner_surface, (WIDTH//2 - banner_surface.get_width()//2, HEIGHT//6))
+
+        if self.show_settings:
+            self.draw_settings_panel(screen)
+
+        if self.transitioning:
+            transition_surface = pygame.Surface((WIDTH, HEIGHT))
+            transition_surface.fill(self.theme['background'])
+            transition_surface.set_alpha(self.transition_alpha)
+            screen.blit(transition_surface, (0, 0))
+
+    def handle_click(self, pos):
+        if self.theme_button.is_clicked(pos):
+            self.toggle_theme()
+            self.sound_manager.play('click')
+            return True
+
+        if self.settings_button.is_clicked(pos):
+            self.show_settings = not self.show_settings
+            self.sound_manager.play('click')
+            return True
+
+        if self.show_settings:
+            if self.language_button.is_clicked(pos):
+                self.cycle_language()
+                self.sound_manager.play('confirmation')
+                return True
+            if self.difficulty_button.is_clicked(pos):
+                self.cycle_difficulty()
+                self.sound_manager.play('confirmation')
+                return True
+            if self.symbols_button.is_clicked(pos):
+                self.toggle_symbols()
+                self.sound_manager.play('confirmation')
+                return True
+            if self.mode_button.is_clicked(pos):
+                self.cycle_mode()
+                self.sound_manager.play('confirmation')
+                return True
+            if self.zen_button.is_clicked(pos):
+                self.toggle_zen_mode()
+                self.sound_manager.play('confirmation')
+                return True
+            if not self.settings_panel_rect.collidepoint(pos):
+                self.show_settings = False
+
+        return super().handle_click(pos)
+
+    def update(self, dt: float) -> None:
+        super().update()
+        for cloud in self.clouds:
+            cloud.update(dt)
+
+        for button in [
+            self.start_button,
+            self.quit_button,
+            self.play_again_button,
+            self.theme_button,
+            self.settings_button,
+        ]:
+            button.update(dt)
+
+        if self.show_settings:
+            for button in [
+                self.language_button,
+                self.difficulty_button,
+                self.symbols_button,
+                self.mode_button,
+                self.zen_button,
+            ]:
+                button.update(dt)
+
+        if self.transitioning:
+            self.transition_alpha += TRANSITION_SPEED * dt
+            if self.transition_alpha >= 255:
+                self.complete_transition()
+
     def complete_transition(self):
-        """Completes the theme transition by switching themes and resetting transition state."""
         self.dark_mode = not self.dark_mode
         self.theme = DARK_THEME if self.dark_mode else LIGHT_THEME
         self.theme_button.text = "LIGHT" if self.dark_mode else "DARK"
-        self.theme_button.color = self.theme['button']
         self.create_background()
+        self.update_button_styles()
         self.transitioning = False
         self.transition_alpha = 0
+
 
 # Combo message class for displaying combo messages
 class ComboMessage(Message):
@@ -1210,8 +2477,24 @@ def main():
                 if not game.handle_click(event.pos):  # Handle click
                     running = False
             elif event.type == pygame.MOUSEMOTION:  # If mouse motion event
-                for button in [game.theme_button, game.start_button, 
-                             game.quit_button, game.play_again_button]:
+                hover_buttons = [
+                    game.theme_button,
+                    game.start_button,
+                    game.quit_button,
+                    game.play_again_button,
+                    game.settings_button,
+                ]
+                if getattr(game, 'show_settings', False):
+                    hover_buttons.extend(
+                        [
+                            game.language_button,
+                            game.difficulty_button,
+                            game.symbols_button,
+                            game.mode_button,
+                            game.zen_button,
+                        ]
+                    )
+                for button in hover_buttons:
                     button.handle_hover(event.pos)  # Handle hover
             elif event.type == pygame.KEYDOWN:  # If key down event
                 game.handle_keyboard_input(event)  # Handle keyboard input

--- a/tests/test_config_and_utils.py
+++ b/tests/test_config_and_utils.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import types
+import importlib.util
+from pathlib import Path
+import unittest
+
+# Ensure pygame can initialize in headless test environments and provide a stub when unavailable.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+try:
+    import pygame  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed in CI where pygame is unavailable
+    pygame = types.ModuleType("pygame")
+    pygame.error = Exception
+
+    class _DummySurface:
+        def __init__(self, size=(0, 0), *_args, **_kwargs):
+            self._size = size
+
+        def fill(self, *_args, **_kwargs):
+            return None
+
+        def blit(self, *_args, **_kwargs):
+            return None
+
+        def get_width(self):
+            return self._size[0]
+
+        def get_height(self):
+            return self._size[1]
+
+        def set_alpha(self, *_args, **_kwargs):
+            return None
+
+        def copy(self):
+            return _DummySurface(self._size)
+
+    class _DummyFont:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def size(self, text):
+            return (len(text) * 8, 16)
+
+        def render(self, text, *_args, **_kwargs):
+            return _DummySurface((len(text) * 8, 16))
+
+    def _noop(*_args, **_kwargs):
+        return None
+
+    pygame.mixer = types.SimpleNamespace(pre_init=_noop)
+    pygame.init = _noop
+    pygame.quit = _noop
+    pygame.font = types.SimpleNamespace(init=_noop, Font=_DummyFont)
+    pygame.time = types.SimpleNamespace(get_ticks=lambda: 0, Clock=lambda: types.SimpleNamespace(tick=lambda *_args: 16))
+    pygame.transform = types.SimpleNamespace(scale=lambda surf, size: _DummySurface(size))
+    pygame.event = types.SimpleNamespace(get=lambda: [])
+
+    class _DisplayModule:
+        def set_mode(self, size):
+            return _DummySurface(size)
+
+        def set_caption(self, *_args, **_kwargs):
+            return None
+
+    pygame.display = _DisplayModule()
+    pygame.SRCALPHA = 0
+    pygame.Surface = _DummySurface
+
+    class _Rect:
+        def __init__(self, x, y, width, height):
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+
+    pygame.Rect = _Rect
+
+    sys.modules["pygame"] = pygame
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "Train-Color-Matcher.py"
+SPEC = importlib.util.spec_from_file_location("train_color_matcher", MODULE_PATH)
+train_color_matcher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(train_color_matcher)
+
+# Import (or stub) pygame after loading the module to access font helpers in the tests themselves.
+import pygame  # type: ignore  # noqa: E402
+
+
+class ConfigValidatorTests(unittest.TestCase):
+    """Unit tests for the configuration validation helpers."""
+
+    def test_validate_color_accepts_rgb_triplets(self):
+        self.assertTrue(train_color_matcher.ConfigValidator.validate_color([10, 20, 30]))
+        self.assertFalse(train_color_matcher.ConfigValidator.validate_color([10, 20]))
+        self.assertFalse(train_color_matcher.ConfigValidator.validate_color([10, 20, 300]))
+
+    def test_validate_window_enforces_minimums(self):
+        defaults = train_color_matcher.ConfigValidator.validate_window({})
+        result = train_color_matcher.ConfigValidator.validate_window(
+            {"window": {"width": 200, "height": 100, "title": 123}}
+        )
+        self.assertEqual(result["width"], defaults["width"])
+        self.assertEqual(result["height"], defaults["height"])
+        self.assertEqual(result["title"], defaults["title"])
+
+    def test_validate_colors_falls_back_to_defaults(self):
+        defaults = train_color_matcher.ConfigValidator.validate_colors({})
+        result = train_color_matcher.ConfigValidator.validate_colors(
+            {"colors": {"red": [-10, 0, 0], "green": "invalid"}}
+        )
+        self.assertEqual(result["red"], defaults["red"])
+        self.assertEqual(result["green"], defaults["green"])
+
+
+class WrapTextTests(unittest.TestCase):
+    """Tests for the text wrapping helper used across UI panels."""
+
+    @classmethod
+    def setUpClass(cls):
+        if hasattr(pygame.font, "init"):
+            pygame.font.init()
+        cls.font = pygame.font.Font(None, 24)
+
+    def test_wrap_text_respects_width_constraints(self):
+        message = "red blue green yellow"
+        max_width = self.font.size("red blue")[0] + 4
+        lines = train_color_matcher.wrap_text(message, self.font, max_width)
+        self.assertGreater(len(lines), 1)
+        for line in lines:
+            self.assertLessEqual(self.font.size(line)[0], max_width)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a unittest suite that exercises ConfigValidator color, window, and palette fallbacks along with the wrap_text helper
- provide a lightweight pygame stub so the tests run in environments without the native dependency

## Testing
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ca3f794750832b9f258197f15075e7